### PR TITLE
add Send & Sync marker trait to Element

### DIFF
--- a/src/dom.rs
+++ b/src/dom.rs
@@ -217,6 +217,9 @@ pub struct Element {
 	he: HELEMENT,
 }
 
+unsafe impl Send for Element {}
+unsafe impl Sync for Element {}
+
 impl Element {
 
 	//\name Creation


### PR DESCRIPTION
It seems like send and share `Element` between threads and call its api from different thread is fine.
add `Send` and `Sync` to `Element`  will allow code like:
```
impl EventHandler {
    fn Download(&self, root: Element) -> Option<Value> {
        thread::spawn(move || {
            ...
            let _ = root.call_function("onSuccess", &make_args!());
        });
        None
    }
}

impl sciter::EventHandler for EventHandler {

    fn attached(&mut self, root: HELEMENT) {
        self.root = Some(Element::from(root));
    }

    fn on_script_call(&mut self, root: HELEMENT, name: &str, argv: &[Value]) -> Option<Value> {
        match name {
            "Download" => self.Download(Element::from(root)),
            _ => None,
        }
    }
}
```
It's much easier to write worker thread.
Above code works fine on my simple project, but I haven't test other api. How should I test all those api? any suggestion?