### PR TITLE
Find all should actually find all

### DIFF
--- a/src/dom.rs
+++ b/src/dom.rs
@@ -788,7 +788,7 @@ impl Element {
 
 	/// Will find all elements starting from this satisfying given css selector(s).
 	pub fn find_all(&self, selector: &str) -> Result<Option<Vec<Element>>> {
-		let cb = FindFirstElement::default();
+		let cb = FindAllElements::default();
 		let all = self.select_elements(selector, cb);
 		all.map(|x| Some(x))
 	}


### PR DESCRIPTION
`find_all` originally only returned 1 element, the first element it found. Because it was using the wrong callback, which terminated iteration after the first match was found.

Tested on local project, works great!