### PR TITLE
Fix incorrect window size when using WindowBuilder::with_pos API

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -5,7 +5,7 @@ use capi::sctypes::*;
 
 pub trait BaseWindow {
 
-	fn create(&mut self, rect: (i32,i32,i32,i32), flags: UINT, parent: HWINDOW) -> HWINDOW;
+	fn create(&mut self, rc: RECT, flags: UINT, parent: HWINDOW) -> HWINDOW;
 
 	fn get_hwnd(&self) -> HWINDOW;
 
@@ -78,14 +78,11 @@ mod windows {
 		}
 
 		/// Create a new native window.
-		fn create(&mut self, rect: (i32,i32,i32,i32), flags: UINT, parent: HWINDOW) -> HWINDOW {
+		fn create(&mut self, rc: RECT, flags: UINT, parent: HWINDOW) -> HWINDOW {
 
 			if (flags & SCITER_CREATE_WINDOW_FLAGS::SW_MAIN as u32) != 0 {
 				OsWindow::init_app();
 			}
-
-			let (x,y,w,h) = rect;
-			let rc = RECT { left: x, top: y, right: x + w, bottom: y + h };
 
 			let cb = ::std::ptr::null();
 			self.flags = flags;
@@ -215,14 +212,11 @@ mod windows {
 		}
 
 		/// Create a new native window.
-		fn create(&mut self, rect: (i32,i32,i32,i32), flags: UINT, parent: HWINDOW) -> HWINDOW {
+		fn create(&mut self, rc: RECT, flags: UINT, parent: HWINDOW) -> HWINDOW {
 
 			if (flags & SCITER_CREATE_WINDOW_FLAGS::SW_MAIN as u32) != 0 {
 				OsWindow::init_app();
 			}
-
-			let (x,y,w,h) = rect;
-			let rc = RECT { left: x, top: y, right: x + w, bottom: y + h };
 
 			let cb = ptr::null();
 			self.flags = flags;
@@ -368,15 +362,13 @@ mod windows {
 		}
 
 		/// Create a new native window.
-		fn create(&mut self, rect: (i32,i32,i32,i32), flags: UINT, parent: HWINDOW) -> HWINDOW {
+		fn create(&mut self, rc: RECT, flags: UINT, parent: HWINDOW) -> HWINDOW {
 
 			if (flags & SCITER_CREATE_WINDOW_FLAGS::SW_MAIN as u32) != 0 {
 				OsWindow::init_app();
 			}
 
-			let (x,y,w,h) = rect;
-			let rc = RECT { left: x, top: y, right: x + w, bottom: y + h };
-			let prc: *const RECT = if w > 0 && h > 0 {
+			let prc: *const RECT = if rc.width() > 0 && rc.height() > 0 {
 				&rc
 			} else {
 				0 as *const RECT

--- a/src/window.rs
+++ b/src/window.rs
@@ -90,8 +90,8 @@ impl Window {
 		Builder::main_window().create()
 	}
 
-	/// Create a new window with the specified position as `rect(x, y, width, height)`, flags and an optional parent window.
-	pub fn create(rect: (i32, i32, i32, i32), flags: SCITER_CREATE_WINDOW_FLAGS, parent: Option<HWINDOW>) -> Window {
+	/// Create a new window with the specified position as `rect(left, top, right, bottom)`, flags and an optional parent window.
+	pub fn create(rect: RECT, flags: SCITER_CREATE_WINDOW_FLAGS, parent: Option<HWINDOW>) -> Window {
 		let mut base = OsWindow::new();
 		let hwnd = base.create(rect, flags as UINT, parent.unwrap_or(0 as HWINDOW));
 		assert!(!hwnd.is_null());
@@ -256,6 +256,17 @@ impl Window {
 }
 
 
+/// Generic rectangle struct.
+/// NOTE that this is different from RECT type as it specifies width and height.
+#[derive(Clone, Copy)]
+pub struct Rectangle {
+	pub x: i32,
+	pub y: i32,
+	pub width: i32,
+	pub height: i32
+}
+
+
 /// Builder pattern for window creation.
 ///
 /// For example,
@@ -350,12 +361,12 @@ impl Builder {
 	}
 
 	/// Specify the exact window rectangle in `(X, Y, W, H)` form.
-	pub fn with_rect(mut self, rect: (i32, i32, i32, i32)) -> Self {
+	pub fn with_rect(mut self, rect: Rectangle) -> Self {
 		self.rect = RECT {
-			left: rect.0,
-			top: rect.1,
-			right: rect.2,
-			bottom: rect.3,
+			left: rect.x,
+			top: rect.y,
+			right: rect.x + rect.width,
+			bottom: rect.y + rect.height,
 		};
 		self
 	}
@@ -403,7 +414,6 @@ impl Builder {
 
 	/// Consume the builder and call [`Window::create()`](struct.Window.html#method.create) with built parameters.
 	pub fn create(self) -> Window {
-		let r = self.rect;
-		Window::create((r.left, r.top, r.right, r.bottom), self.flags, self.parent)
+		Window::create(self.rect, self.flags, self.parent)
 	}
 }


### PR DESCRIPTION
Usage of `WindowBuilder::with_pos()` API leads to incorrect window size.

This happens because two implementations of a rectangle are mixed:

* Sciter API expects a `RECT` struct that consists of `left`, `top`, `right` and `bottom` fields

* WindowBuilder works with a tuple that represents `x`, `y`, `width` and `height` fields.

This PR fixes incorrect behavior by enforcing exact types of rectangles on dependent APIs.