### PR TITLE
Global var refresh

### DIFF
--- a/src/capi/scapi.rs
+++ b/src/capi/scapi.rs
@@ -281,10 +281,11 @@ pub struct ISciterAPI
 	pub SciterGetElementAsset: extern "system" fn(el: HELEMENT, atomv: som_atom_t, pass: *mut *mut som_asset_t) -> SCDOM_RESULT,
 
 	// since 4.4.4.6 (yet disabled)
+	// since 4.4.8.26
 	/// Set global value by path.
-	pub SciterSetVariable: extern "system" fn(hwndOrNull: HWINDOW, path: LPCWSTR, value: *const VALUE) -> UINT,
+	pub SciterSetVariable: extern "system" fn(hwndOrNull: HWINDOW, path: LPCSTR, value: *const VALUE) -> SCDOM_RESULT,
 	/// Get global value by path.
-	pub SciterGetVariable: extern "system" fn(hwndOrNull: HWINDOW, path: LPCWSTR, value: *mut VALUE) -> UINT,
+	pub SciterGetVariable: extern "system" fn(hwndOrNull: HWINDOW, path: LPCSTR, value: *mut VALUE) -> SCDOM_RESULT,
 
 	// since 4.4.5.4
 	pub SciterElementUnwrap: extern "system" fn(pval: *const VALUE, ppElement: *mut HELEMENT) -> SCDOM_RESULT,

--- a/src/capi/scbehavior.rs
+++ b/src/capi/scbehavior.rs
@@ -250,6 +250,8 @@ impl KEYBOARD_STATES {
 	pub const CONTROL_KEY_PRESSED: u32 = 0x01;
 	pub const SHIFT_KEY_PRESSED: u32 = 0x02;
 	pub const ALT_KEY_PRESSED: u32 = 0x04;
+	pub const RIGHT_SHIFT_KEY_PRESSED: u32 = 0x08;
+	pub const CMD_KEY_PRESSED: u32 = 0x10;
 }
 
 impl std::convert::From<u32> for KEYBOARD_STATES {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -608,26 +608,26 @@ pub fn set_options(options: RuntimeOptions) -> std::result::Result<(), ()> {
 /// Set a global variable by its path.
 ///
 /// See the per-window [`Window::set_variable`](window/struct.Window.html#method.set_variable).
-pub fn set_variable(path: &str, value: Value) -> std::result::Result<(), ()> {
-	let ws = s2w!(path);
+pub fn set_variable(path: &str, value: Value) -> dom::Result<()> {
+	let ws = s2u!(path);
 	let ok = (_API.SciterSetVariable)(std::ptr::null_mut(), ws.as_ptr(), value.as_cptr());
-	if ok != 0 {
+	if ok == dom::SCDOM_RESULT::OK {
 		Ok(())
 	} else {
-		Err(())
+		Err(ok)
 	}
 }
 
 /// Get a global variable by its path.
 ///
 /// See the per-window [`Window::get_variable`](window/struct.Window.html#method.get_variable).
-pub fn get_variable(path: &str) -> std::result::Result<Value, ()> {
-	let ws = s2w!(path);
+pub fn get_variable(path: &str) -> dom::Result<Value> {
+	let ws = s2u!(path);
 	let mut value = Value::new();
 	let ok = (_API.SciterGetVariable)(std::ptr::null_mut(), ws.as_ptr(), value.as_mut_ptr());
-	if ok != 0 {
+	if ok == dom::SCDOM_RESULT::OK {
 		Ok(value)
 	} else {
-		Err(())
+		Err(ok)
 	}
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -31,7 +31,7 @@ use capi::sctypes::*;
 
 use platform::{BaseWindow, OsWindow};
 use host::{Host, HostHandler};
-use dom::event::{EventHandler};
+use dom::{self, event::{EventHandler}};
 
 use std::rc::Rc;
 
@@ -345,27 +345,27 @@ impl Window {
 	/// Set a window variable by its path.
 	///
 	/// See the global [`sciter::set_variable`](../fn.set_variable.html).
-	pub fn set_variable(&self, path: &str, value: crate::Value) -> std::result::Result<(), ()> {
-		let ws = s2w!(path);
+	pub fn set_variable(&self, path: &str, value: crate::Value) -> dom::Result<()> {
+		let ws = s2u!(path);
 		let ok = (_API.SciterSetVariable)(self.get_hwnd(), ws.as_ptr(), value.as_cptr());
-		if ok != 0 {
+		if ok == dom::SCDOM_RESULT::OK {
 			Ok(())
 		} else {
-			Err(())
+			Err(ok)
 		}
 	}
 
 	/// Get a window variable by its path.
 	///
 	/// See the global [`sciter::get_variable`](../fn.get_variable.html).
-	pub fn get_variable(&self, path: &str) -> std::result::Result<crate::Value, ()> {
-		let ws = s2w!(path);
+	pub fn get_variable(&self, path: &str) -> dom::Result<crate::Value> {
+		let ws = s2u!(path);
 		let mut value = crate::Value::new();
 		let ok = (_API.SciterGetVariable)(self.get_hwnd(), ws.as_ptr(), value.as_mut_ptr());
-		if ok != 0 {
+		if ok == dom::SCDOM_RESULT::OK {
 			Ok(value)
 		} else {
-			Err(())
+			Err(ok)
 		}
 	}
 


### PR DESCRIPTION
Set a global script variable from native code since Sciter 4.4.8.26.

It was introduced (yet disabled) in 4.4.4.6. enabled in 4.4.8.26.

refs: 0ca353a8fa