### PR TITLE
compile with rustc 1.90.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 .vscode/
 .vs/
+docs/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "sciter-rs"
 version = "0.5.58"
+edition = "2024"
 description = "Rust bindings for Sciter - Embeddable HTML/CSS/script engine (cross-platform desktop GUI toolkit). Also capable with DirectX / OpenGL."
 keywords = ["gui", "gtk", "cocoa", "opengl", "skia"]
 categories = ["gui", "web-programming", "rendering::graphics-api", "api-bindings"]
@@ -50,7 +51,8 @@ windowless = []
 
 [dependencies]
 libc = "0.2"
-lazy_static = "1.0"
+lazy_static = "1.5.0"
+bitflags = "2.9.4"
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 objc = "0.2"

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -3,11 +3,11 @@
 #[macro_use]
 extern crate sciter;
 
-use sciter::dom::event::{MethodParams, DRAW_EVENTS, EVENT_GROUPS};
-use sciter::dom::{Element, HELEMENT};
-use sciter::graphics::{self, rgb, Graphics, HGFX};
-use sciter::types::RECT;
 use sciter::Value;
+use sciter::{DRAW_EVENTS, EVENT_GROUPS};
+use sciter::dom::{Element, HELEMENT, event::MethodParams};
+use sciter::graphics::{self, Graphics, HGFX, rgb};
+use sciter::types::RECT;
 
 // 24:60:60, will be drawn as analog clock
 type Time = [u8; 3usize];
@@ -29,323 +29,317 @@ type Time = [u8; 3usize];
 ///
 #[derive(Default)]
 struct Clock {
-  element: Option<Element>,
-  now: Time,
-  gmt: i8,
-  is_frozen: bool,
+	element: Option<Element>,
+	now: Time,
+	gmt: i8,
+	is_frozen: bool,
 }
 
 impl sciter::EventHandler for Clock {
-  /// Claim what kind of events we want to receive.
-  fn get_subscription(&mut self) -> Option<EVENT_GROUPS> {
-    // we need timer and draw events
-    // also behavior method calls
-    Some(EVENT_GROUPS::HANDLE_TIMER
-      | EVENT_GROUPS::HANDLE_DRAW
-      | EVENT_GROUPS::HANDLE_METHOD_CALL
-    )
-  }
+	/// Claim what kind of events we want to receive.
+	fn get_subscription(&mut self) -> Option<EVENT_GROUPS> {
+		// we need timer and draw events
+		// also behavior method calls
+		Some(EVENT_GROUPS::HANDLE_TIMER | EVENT_GROUPS::HANDLE_DRAW | EVENT_GROUPS::HANDLE_METHOD_CALL)
+	}
 
-  /// Our element is constructed. But scripts in HTML are not loaded yet.
-  fn attached(&mut self, root: HELEMENT) {
-    self.element = Some(Element::from(root));
-    let me = self.element.as_ref().unwrap();
+	/// Our element is constructed. But scripts in HTML are not loaded yet.
+	fn attached(&mut self, root: HELEMENT) {
+		self.element = Some(Element::from(root));
+		let me = self.element.as_ref().unwrap();
 
-    // get attributes to initialize our clock
-    if let Some(attr) = me.get_attribute("utc") {
-      if let Ok(v) = attr.parse::<i8>() {
-        self.gmt = v;
-      }
-    }
+		// get attributes to initialize our clock
+		if let Some(attr) = me.get_attribute("utc") {
+			if let Ok(v) = attr.parse::<i8>() {
+				self.gmt = v;
+			}
+		}
 
-    // we don't update frozen clocks
-    if let Some(_attr) = me.get_attribute("frozen") {
-      self.is_frozen = true;
-    }
+		// we don't update frozen clocks
+		if let Some(_attr) = me.get_attribute("frozen") {
+			self.is_frozen = true;
+		}
 
-    // timer to redraw our clock
-    if !self.is_frozen {
-      me.start_timer(300, 1).expect("Can't set timer");
-    }
-  }
+		// timer to redraw our clock
+		if !self.is_frozen {
+			me.start_timer(300, 1).expect("Can't set timer");
+		}
+	}
 
-  /// Our behavior methods.
-  fn on_method_call(&mut self, _root: HELEMENT, params: MethodParams) -> bool {
-    match params {
-      MethodParams::GetValue(retval) => {
-        // engine wants out current value (e.g. `current = element.value`)
-        let v: Value = self.now.iter().map(|v| i32::from(*v)).collect();
-        println!("return current time as {:?}", v);
-        *retval = v;
-      }
+	/// Our behavior methods.
+	fn on_method_call(&mut self, _root: HELEMENT, params: MethodParams) -> bool {
+		match params {
+			MethodParams::GetValue(retval) => {
+				// engine wants out current value (e.g. `current = element.value`)
+				let v: Value = self.now.iter().map(|v| i32::from(*v)).collect();
+				println!("return current time as {:?}", v);
+				*retval = v;
+			}
 
-      MethodParams::SetValue(v) => {
-        // engine sets our value (e.g. `element.value = new`)
-        println!("set current time from {:?}", v);
+			MethodParams::SetValue(v) => {
+				// engine sets our value (e.g. `element.value = new`)
+				println!("set current time from {:?}", v);
 
-        // "10:20:30"
-        if v.is_string() {
-          let s = v.as_string().unwrap();
-          let t = s.split(':').take(3).map(|n| n.parse::<u8>());
-          let mut new_time = Time::default();
-          for (i, n) in t.enumerate() {
-            if let Err(_) = n {
-              eprintln!("clock::set_value({:?}) is invalid", v);
-              return true; // consume this event anyway
-            }
-            new_time[i] = n.unwrap();
-          }
-          // use it as a new time
-          self.set_time(new_time);
+				// "10:20:30"
+				if v.is_string() {
+					let s = v.as_string().unwrap();
+					let t = s.split(':').take(3).map(|n| n.parse::<u8>());
+					let mut new_time = Time::default();
+					for (i, n) in t.enumerate() {
+						if let Err(_) = n {
+							eprintln!("clock::set_value({:?}) is invalid", v);
+							return true; // consume this event anyway
+						}
+						new_time[i] = n.unwrap();
+					}
+					// use it as a new time
+					self.set_time(new_time);
 
-        // [10, 20, 30]
-        } else if v.is_varray() {
-          let mut new_time = Time::default();
-          for (i, n) in v.values().take(3).map(|n| n.to_int()).enumerate() {
-            if n.is_none() {
-              eprintln!("clock::set_value({:?}) is invalid", v);
-              return true;
-            }
-            new_time[i] = n.unwrap() as u8
-          }
-          // use it as a new time
-          self.set_time(new_time);
-        } else {
-          // unknown format
-          eprintln!("clock::set_value({:?}) is unsupported", v);
-          return true;
-        }
-      }
+				// [10, 20, 30]
+				} else if v.is_varray() {
+					let mut new_time = Time::default();
+					for (i, n) in v.values().take(3).map(|n| n.to_int()).enumerate() {
+						if n.is_none() {
+							eprintln!("clock::set_value({:?}) is invalid", v);
+							return true;
+						}
+						new_time[i] = n.unwrap() as u8
+					}
+					// use it as a new time
+					self.set_time(new_time);
+				} else {
+					// unknown format
+					eprintln!("clock::set_value({:?}) is unsupported", v);
+					return true;
+				}
+			}
 
-      _ => {
-        // unsupported event, skip it
-        return false;
-      }
-    }
+			_ => {
+				// unsupported event, skip it
+				return false;
+			}
+		}
 
-    // mark this event as handled (consume it)
-    return true;
-  }
+		// mark this event as handled (consume it)
+		return true;
+	}
 
-  /// Redraw our element on each tick.
-  fn on_timer(&mut self, root: HELEMENT, _timer_id: u64) -> bool {
-    if self.update_time() {
-      // redraw our clock
-      Element::from(root).refresh().expect("Can't refresh element");
-    }
-    true
-  }
+	/// Redraw our element on each tick.
+	fn on_timer(&mut self, root: HELEMENT, _timer_id: u64) -> bool {
+		if self.update_time() {
+			// redraw our clock
+			Element::from(root).refresh().expect("Can't refresh element");
+		}
+		true
+	}
 
-  /// Request to draw our element.
-  fn on_draw(&mut self, _root: HELEMENT, gfx: HGFX, area: &RECT, layer: DRAW_EVENTS) -> bool {
-    if layer == DRAW_EVENTS::DRAW_CONTENT {
-      // draw content only
-      // leave the back- and foreground to be default
-      let mut gfx = Graphics::from(gfx);
+	/// Request to draw our element.
+	fn on_draw(&mut self, _root: HELEMENT, gfx: HGFX, area: &RECT, layer: DRAW_EVENTS) -> bool {
+		if layer == DRAW_EVENTS::DRAW_CONTENT {
+			// draw content only
+			// leave the back- and foreground to be default
+			let mut gfx = Graphics::from(gfx);
 			self
 				.draw_clock(&mut gfx, &area)
-				.map_err(|e| println!("error in draw_clock: {:?}", e) )
+				.map_err(|e| println!("error in draw_clock: {:?}", e))
 				.ok();
 		}
 
-    // allow default drawing anyway
-    return false;
-  }
+		// allow default drawing anyway
+		return false;
+	}
 }
 
 // 360°
 const PI2: f32 = 2.0 * std::f32::consts::PI;
 
 impl Clock {
-  /// Update current time and say if changed.
-  fn update_time(&mut self) -> bool {
-    if self.is_frozen {
-      return false;
-    }
+	/// Update current time and say if changed.
+	fn update_time(&mut self) -> bool {
+		if self.is_frozen {
+			return false;
+		}
 
-    // ask our script for the current time
-    if let Some(now) = self.get_time() {
-      let update = self.now != now;
-      self.now = now;
-      update
-    } else {
-      false
-    }
-  }
+		// ask our script for the current time
+		if let Some(now) = self.get_time() {
+			let update = self.now != now;
+			self.now = now;
+			update
+		} else {
+			false
+		}
+	}
 
-  /// Set the new time and redraw our element.
-  fn set_time(&mut self, new_time: Time) {
-    // set new time and redraw our clock
-    self.now = new_time;
-    if let Some(el) = self.element.as_ref() {
-      el.refresh().ok();
-    }
-  }
+	/// Set the new time and redraw our element.
+	fn set_time(&mut self, new_time: Time) {
+		// set new time and redraw our clock
+		self.now = new_time;
+		if let Some(el) = self.element.as_ref() {
+			el.refresh().ok();
+		}
+	}
 
-  /// Get current time from script.
-  fn get_time(&self) -> Option<Time> {
-    let el = self.element.as_ref().unwrap();
-    let script_func = if self.is_frozen { "getLocalTime" } else { "getUtcTime" };
-    if let Ok(time) = el.call_function(script_func, &make_args!(self.gmt as i32)) {
-      assert_eq!(time.len(), 3);
-      let mut now = Time::default();
-      for (i, n) in time.values().take(3).map(|n| n.to_int()).enumerate() {
-        now[i] = n.unwrap() as u8;
-      }
-      Some(now)
-    } else {
-      eprintln!("error: can't eval get time script");
-      None
-    }
-  }
+	/// Get current time from script.
+	fn get_time(&self) -> Option<Time> {
+		let el = self.element.as_ref().unwrap();
+		let script_func = if self.is_frozen { "getLocalTime" } else { "getUtcTime" };
+		if let Ok(time) = el.call_function(script_func, &make_args!(self.gmt as i32)) {
+			assert_eq!(time.len(), 3);
+			let mut now = Time::default();
+			for (i, n) in time.values().take(3).map(|n| n.to_int()).enumerate() {
+				now[i] = n.unwrap() as u8;
+			}
+			Some(now)
+		} else {
+			eprintln!("error: can't eval get time script");
+			None
+		}
+	}
 
-  /// Draw our element.
-  fn draw_clock(&mut self, gfx: &mut Graphics, area: &RECT) -> graphics::Result<()> {
-    // save previous state
-    let mut gfx = gfx.save_state()?;
+	/// Draw our element.
+	fn draw_clock(&mut self, gfx: &mut Graphics, area: &RECT) -> graphics::Result<()> {
+		// save previous state
+		let mut gfx = gfx.save_state()?;
 
-    // setup our attributes
-    let left = area.left as f32;
-    let top = area.top as f32;
-    let width = area.width() as f32;
-    let height = area.height() as f32;
+		// setup our attributes
+		let left = area.left as f32;
+		let top = area.top as f32;
+		let width = area.width() as f32;
+		let height = area.height() as f32;
 
-    let scale = if width < height { width / 300.0 } else { height / 300.0 };
+		let scale = if width < height { width / 300.0 } else { height / 300.0 };
 
-    // translate to its center and rotate 45° left.
-    gfx
-      .translate((left + width / 2.0, top + height / 2.0))?
-      .scale((scale, scale))?
-      .rotate(-PI2 / 4.)?;
+		// translate to its center and rotate 45° left.
+		gfx
+			.translate((left + width / 2.0, top + height / 2.0))?
+			.scale((scale, scale))?
+			.rotate(-PI2 / 4.)?;
 
-    gfx.line_color(0)?.line_cap(graphics::LINE_CAP::ROUND)?;
+		gfx.line_color(0)?.line_cap(graphics::LINE_CAP::ROUND)?;
 
-    // draw clock background
-    self.draw_outline(&mut *gfx)?;
+		// draw clock background
+		self.draw_outline(&mut *gfx)?;
 
-    // draw clock sticks
+		// draw clock sticks
 		self.draw_time(&mut *gfx)?;
 
-    Ok(())
-  }
+		Ok(())
+	}
 
-  /// Draw clock static area (hour/minute marks).
-  fn draw_outline(&mut self, gfx: &mut Graphics) -> graphics::Result<()> {
-    // hour marks (every 5 ticks)
-    {
-      let mut gfx = gfx.save_state()?;
-      gfx.line_width(8.0)?.line_color(rgb(0x32, 0x5F, 0xA2))?;
+	/// Draw clock static area (hour/minute marks).
+	fn draw_outline(&mut self, gfx: &mut Graphics) -> graphics::Result<()> {
+		// hour marks (every 5 ticks)
+		{
+			let mut gfx = gfx.save_state()?;
+			gfx.line_width(8.0)?.line_color(rgb(0x32, 0x5F, 0xA2))?;
 
-      for _ in 0..12 {
-        gfx.rotate(PI2 / 12.)?.line((137., 0.), (144., 0.))?;
-      }
-    }
+			for _ in 0..12 {
+				gfx.rotate(PI2 / 12.)?.line((137., 0.), (144., 0.))?;
+			}
+		}
 
-    // minute marks (every but 5th tick)
-    {
-      let mut gfx = gfx.save_state()?;
-      gfx.line_width(3.0)?.line_color(rgb(0xA5, 0x2A, 0x2A))?;
+		// minute marks (every but 5th tick)
+		{
+			let mut gfx = gfx.save_state()?;
+			gfx.line_width(3.0)?.line_color(rgb(0xA5, 0x2A, 0x2A))?;
 
-      for i in 0..60 {
-        if i % 5 != 0 {
-          // skip hours
-          gfx.line((143., 0.), (146., 0.))?;
-        }
-        gfx.rotate(PI2 / 60.)?;
-      }
-    }
-    Ok(())
-  }
+			for i in 0..60 {
+				if i % 5 != 0 {
+					// skip hours
+					gfx.line((143., 0.), (146., 0.))?;
+				}
+				gfx.rotate(PI2 / 60.)?;
+			}
+		}
+		Ok(())
+	}
 
-  /// Draw clock arrows.
-  fn draw_time(&mut self, gfx: &mut Graphics) -> graphics::Result<()> {
-    let time = &self.now;
-    let hours = f32::from(time[0]);
-    let minutes = f32::from(time[1]);
-    let seconds = f32::from(time[2]);
+	/// Draw clock arrows.
+	fn draw_time(&mut self, gfx: &mut Graphics) -> graphics::Result<()> {
+		let time = &self.now;
+		let hours = f32::from(time[0]);
+		let minutes = f32::from(time[1]);
+		let seconds = f32::from(time[2]);
 
-    {
-      // hours
-      let mut gfx = gfx.save_state()?;
+		{
+			// hours
+			let mut gfx = gfx.save_state()?;
 
-      // 2PI*/12, 2PI/720,
-      gfx.rotate(hours * (PI2 / 12 as f32) + minutes * (PI2 / (12 * 60) as f32) + seconds * (PI2 / (12 * 60 * 60) as f32))?;
+			// 2PI*/12, 2PI/720,
+			gfx.rotate(hours * (PI2 / 12 as f32) + minutes * (PI2 / (12 * 60) as f32) + seconds * (PI2 / (12 * 60 * 60) as f32))?;
 
-      gfx
-        .line_width(14.0)?
-        .line_color(rgb(0x32, 0x5F, 0xA2))?
-        .line((-20., 0.), (70., 0.))?;
-    }
-    {
-      // minutes
-      let mut gfx = gfx.save_state()?;
+			gfx
+				.line_width(14.0)?
+				.line_color(rgb(0x32, 0x5F, 0xA2))?
+				.line((-20., 0.), (70., 0.))?;
+		}
+		{
+			// minutes
+			let mut gfx = gfx.save_state()?;
 
-      gfx.rotate(minutes * (PI2 / 60 as f32) + seconds * (PI2 / (60 * 60) as f32))?;
+			gfx.rotate(minutes * (PI2 / 60 as f32) + seconds * (PI2 / (60 * 60) as f32))?;
 
-      gfx
-        .line_width(10.0)?
-        .line_color(rgb(0x32, 0x5F, 0xA2))?
-        .line((-28., 0.), (100., 0.))?;
-    }
-    {
-      // seconds
-      let mut gfx = gfx.save_state()?;
+			gfx
+				.line_width(10.0)?
+				.line_color(rgb(0x32, 0x5F, 0xA2))?
+				.line((-28., 0.), (100., 0.))?;
+		}
+		{
+			// seconds
+			let mut gfx = gfx.save_state()?;
 
-      gfx.rotate(seconds * (PI2 / 60 as f32))?;
+			gfx.rotate(seconds * (PI2 / 60 as f32))?;
 
-      gfx
-        .line_width(6.0)?
-        .line_color(rgb(0xD4, 0, 0))?
-        .fill_color(rgb(0xD4, 0, 0))?
-        .line((-30., 0.), (83., 0.))?
-        .circle((0., 0.), 10.)?;
-    }
-    Ok(())
-  }
+			gfx
+				.line_width(6.0)?
+				.line_color(rgb(0xD4, 0, 0))?
+				.fill_color(rgb(0xD4, 0, 0))?
+				.line((-30., 0.), (83., 0.))?
+				.circle((0., 0.), 10.)?;
+		}
+		Ok(())
+	}
 }
-
 
 ////////////////////////////////////
 #[derive(Default)]
 struct Text;
 
 impl sciter::EventHandler for Text {
-  fn get_subscription(&mut self) -> Option<EVENT_GROUPS> {
-    Some(EVENT_GROUPS::HANDLE_DRAW)
-  }
-
-  fn attached(&mut self, _root: HELEMENT) {
+	fn get_subscription(&mut self) -> Option<EVENT_GROUPS> {
+		Some(EVENT_GROUPS::HANDLE_DRAW)
 	}
 
+	fn attached(&mut self, _root: HELEMENT) {}
+
 	fn on_draw(&mut self, _root: HELEMENT, gfx: HGFX, area: &RECT, layer: DRAW_EVENTS) -> bool {
-    if layer == DRAW_EVENTS::DRAW_CONTENT {
-      // draw content only
-      // leave the back- and foreground to be default
+		if layer == DRAW_EVENTS::DRAW_CONTENT {
+			// draw content only
+			// leave the back- and foreground to be default
 			let mut gfx = Graphics::from(gfx);
 			let e = Element::from(_root);
 			self
 				.draw_text(&e, &mut gfx, &area)
-				.map_err(|e| println!("error in draw_clock: {:?}", e) )
+				.map_err(|e| println!("error in draw_clock: {:?}", e))
 				.ok();
 
-				return true;
+			return true;
 		}
 
-    // allow default drawing anyway
-    return false;
-  }
+		// allow default drawing anyway
+		return false;
+	}
 }
 
 impl Text {
-  fn draw_text(&mut self, e: &Element, gfx: &mut Graphics, area: &RECT) -> graphics::Result<()> {
-
-    // save previous state
-    let mut gfx = gfx.save_state()?;
+	fn draw_text(&mut self, e: &Element, gfx: &mut Graphics, area: &RECT) -> graphics::Result<()> {
+		// save previous state
+		let mut gfx = gfx.save_state()?;
 
 		// setup our attributes
-    // let left = area.left as f32;
-    // let top = area.top as f32;
-    // let width = area.width() as f32;
+		// let left = area.left as f32;
+		// let top = area.top as f32;
+		// let width = area.width() as f32;
 		// let height = area.height() as f32;
 
 		// println!("text::draw on {} at {} {} {} {}", e, left, top, width, height);
@@ -360,9 +354,9 @@ impl Text {
 }
 
 fn main() {
-  let mut frame = sciter::WindowBuilder::main_window().with_size((800, 600)).create();
-  frame.register_behavior("native-clock", || Box::new(Clock::default()));
-  frame.register_behavior("native-text", || Box::new(Text::default()));
-  frame.load_html(include_bytes!("clock.htm"), Some("example://clock.htm"));
-  frame.run_app();
+	let mut frame = sciter::WindowBuilder::main_window().with_size((800, 600)).create();
+	frame.register_behavior("native-clock", || Box::new(Clock::default()));
+	frame.register_behavior("native-text", || Box::new(Text::default()));
+	frame.load_html(include_bytes!("clock.htm"), Some("example://clock.htm"));
+	frame.run_app();
 }

--- a/examples/dom.rs
+++ b/examples/dom.rs
@@ -3,16 +3,14 @@
 
 extern crate sciter;
 
-use sciter::{Value, Element, HELEMENT};
 use sciter::dom::event::*;
-
-
+use sciter::{BEHAVIOR_EVENTS, EVENT_GROUPS, PHASE_MASK};
+use sciter::{Element, HELEMENT, Value};
 
 #[derive(Default)]
 struct DocumentHandler;
 
 impl sciter::EventHandler for DocumentHandler {
-
 	fn attached(&mut self, _root: sciter::HELEMENT) {
 		println!("attached");
 	}
@@ -23,7 +21,6 @@ impl sciter::EventHandler for DocumentHandler {
 	}
 
 	fn document_complete(&mut self, root: sciter::HELEMENT, source: sciter::HELEMENT) {
-
 		println!("document is loaded.");
 
 		let root = Element::from(root);
@@ -65,9 +62,9 @@ impl sciter::EventHandler for DocumentHandler {
 			let html = h1.get_html(true);
 			assert_eq!(html.as_slice(), br"<h1>Herman Melville - Moby-Dick</h1>".as_ref());
 
-			let value = h1.get_value();
-			assert!(value.is_string());
-			assert_eq!(value.as_string().unwrap(), text);
+			// let value = h1.get_value();
+			// assert!(value.is_string());
+			// assert_eq!(value.as_string().unwrap(), text);
 		}
 
 		if let Some(mut h1) = body.first_child() {
@@ -113,7 +110,6 @@ impl sciter::EventHandler for DocumentHandler {
 		}
 
 		if let Ok(Some(mut body)) = root.find_first("html > body") {
-
 			println!("creating some elments");
 
 			// DOM manipulation.
@@ -125,7 +121,7 @@ impl sciter::EventHandler for DocumentHandler {
 			div.set_style_attribute("padding", "5dip");
 
 			let mut lb = Element::with_text("label", "Output: ").unwrap();
-			div.append(&lb).expect("wtf?");	// push as reference, we can access this `lb` still.
+			div.append(&lb).expect("wtf?"); // push as reference, we can access this `lb` still.
 
 			let mut date = Element::with_type("input", "date").unwrap();
 			date.set_attribute("id", "mydate");
@@ -136,7 +132,6 @@ impl sciter::EventHandler for DocumentHandler {
 			date.set_style_attribute("width", "100px");
 			date.set_style_attribute("outline", "1px dotted gray");
 			date.set_style_attribute("margin", "10px");
-
 
 			lb.set_attribute("accesskey", "o");
 			lb.set_style_attribute("color", "lightblue");
@@ -165,7 +160,6 @@ impl sciter::EventHandler for DocumentHandler {
 			e.set_style_attribute("font-style", "italic");
 		}
 	}
-
 }
 
 #[derive(Default)]
@@ -175,7 +169,6 @@ struct ProgressHandler {
 }
 
 impl sciter::EventHandler for ProgressHandler {
-
 	fn get_subscription(&mut self) -> Option<EVENT_GROUPS> {
 		Some(default_events() | EVENT_GROUPS::HANDLE_TIMER)
 	}
@@ -194,14 +187,21 @@ impl sciter::EventHandler for ProgressHandler {
 		println!("detaching from {}", root);
 	}
 
-	fn on_event(&mut self, root: HELEMENT, source: HELEMENT, target: HELEMENT, code: BEHAVIOR_EVENTS, phase: PHASE_MASK, reason: EventReason) -> bool {
+	fn on_event(
+		&mut self,
+		root: HELEMENT,
+		source: HELEMENT,
+		target: HELEMENT,
+		code: BEHAVIOR_EVENTS,
+		phase: PHASE_MASK,
+		reason: EventReason,
+	) -> bool {
 		if phase != PHASE_MASK::BUBBLING {
 			return false;
 		}
 
 		match code {
 			BEHAVIOR_EVENTS::BUTTON_CLICK => {
-
 				let source = Element::from(source);
 				let mut target = Element::from(target);
 
@@ -225,7 +225,7 @@ impl sciter::EventHandler for ProgressHandler {
 
 				true
 			}
-			_ => false
+			_ => false,
 		}
 	}
 
@@ -255,10 +255,7 @@ impl sciter::EventHandler for ProgressHandler {
 }
 
 fn main() {
-  let mut frame = sciter::WindowBuilder::main_window()
-		.with_size((750, 950))
-		.debug()
-		.create();
+	let mut frame = sciter::WindowBuilder::main_window().with_size((750, 950)).debug().create();
 
 	println!("attaching an event handler for the whole window");
 	frame.event_handler(DocumentHandler::default());

--- a/examples/fire_event.rs
+++ b/examples/fire_event.rs
@@ -4,7 +4,7 @@
 
 extern crate sciter;
 
-use sciter::Element;
+use sciter::{Element, BEHAVIOR_EVENTS, PHASE_MASK};
 use self::sciter::dom::event::*;
 use self::sciter::dom::HELEMENT;
 use self::sciter::value::Value;

--- a/examples/som.rs
+++ b/examples/som.rs
@@ -2,7 +2,10 @@
 // #![windows_subsystem="windows"]
 extern crate sciter;
 
-use sciter::{HELEMENT, types::{BOOL, VALUE}};
+use sciter::{
+	HELEMENT,
+	types::{BOOL, VALUE},
+};
 
 #[derive(Default)]
 pub struct Object {
@@ -27,52 +30,52 @@ impl sciter::om::Passport for Object {
 	fn get_passport(&self) -> &'static sciter::om::som_passport_t {
 		use sciter::om::*;
 
-		extern "C" fn on_print(thing: *mut som_asset_t, _argc: u32, _argv: *const VALUE, p_result: &mut VALUE) -> BOOL
-		{
+		extern "C" fn on_print(thing: *mut som_asset_t, _argc: u32, _argv: *const VALUE, p_result: &mut VALUE) -> BOOL {
 			let me = IAsset::<Object>::from_raw(&thing);
 			let r = me.print();
 			let r: sciter::Value = r.into();
 			r.pack_to(p_result);
 			return true as BOOL;
 		}
-		extern "C" fn on_add_year(thing: *mut som_asset_t, argc: u32, argv: *const VALUE, p_result: &mut VALUE) -> BOOL
-		{
+		extern "C" fn on_add_year(thing: *mut som_asset_t, argc: u32, argv: *const VALUE, p_result: &mut VALUE) -> BOOL {
 			let me = IAsset::<Object>::from_raw(&thing);
 
-			let args = unsafe { sciter::Value::unpack_from(argv, argc) };
+			let args = sciter::Value::unpack_from(argv, argc);
 			let required = 1;
 			if args.len() != required {
-				let r = sciter::Value::error(&format!("{} error: {} of {} arguments provided.", "Object::add_year", args.len(), required));
+				let r = sciter::Value::error(&format!(
+					"{} error: {} of {} arguments provided.",
+					"Object::add_year",
+					args.len(),
+					required
+				));
 				r.pack_to(p_result);
 				return true as BOOL;
 			}
 
-			let r = me.add_year(
-				match sciter::FromValue::from_value(&args[0]) {
-					Some(arg) => arg,
-					None => {
-							let r = sciter::Value::error(&format!("{} error: invalid type of {} argument ({} expected, {:?} provided).",
-								"Object::add_year", 0, "i32", &args[0]
-						));
-						r.pack_to(p_result);
-						return true as BOOL;
-					}
-				},
-			);
+			let r = me.add_year(match sciter::FromValue::from_value(&args[0]) {
+				Some(arg) => arg,
+				None => {
+					let r = sciter::Value::error(&format!(
+						"{} error: invalid type of {} argument ({} expected, {:?} provided).",
+						"Object::add_year", 0, "i32", &args[0]
+					));
+					r.pack_to(p_result);
+					return true as BOOL;
+				}
+			});
 			let r: sciter::Value = r.into();
 			r.pack_to(p_result);
 			return true as BOOL;
 		}
 
-		extern "C" fn on_get_age(thing: *mut som_asset_t, p_value: &mut VALUE) -> BOOL
-		{
+		extern "C" fn on_get_age(thing: *mut som_asset_t, p_value: &mut VALUE) -> BOOL {
 			let me = IAsset::<Object>::from_raw(&thing);
 			let r = sciter::Value::from(&me.age);
 			r.pack_to(p_value);
 			return true as BOOL;
 		}
-		extern "C" fn on_set_age(thing: *mut som_asset_t, p_value: &VALUE) -> BOOL
-		{
+		extern "C" fn on_set_age(thing: *mut som_asset_t, p_value: &VALUE) -> BOOL {
 			let me = IAsset::<Object>::from_raw(&thing);
 			use sciter::FromValue;
 			let v = sciter::Value::from(p_value);
@@ -84,15 +87,13 @@ impl sciter::om::Passport for Object {
 			}
 		}
 
-		extern "C" fn on_get_name(thing: *mut som_asset_t, p_value: &mut VALUE) -> BOOL
-		{
+		extern "C" fn on_get_name(thing: *mut som_asset_t, p_value: &mut VALUE) -> BOOL {
 			let me = IAsset::<Object>::from_raw(&thing);
 			let r = sciter::Value::from(&me.name);
 			r.pack_to(p_value);
 			return true as BOOL;
 		}
-		extern "C" fn on_set_name(thing: *mut som_asset_t, p_value: &VALUE) -> BOOL
-		{
+		extern "C" fn on_set_name(thing: *mut som_asset_t, p_value: &VALUE) -> BOOL {
 			let me = IAsset::<Object>::from_raw(&thing);
 			use sciter::FromValue;
 			let v = sciter::Value::from(p_value);
@@ -108,12 +109,12 @@ impl sciter::om::Passport for Object {
 
 		let mut methods = Box::new(ObjectMethods::default());
 
-		let mut method = &mut methods[0];
+		let method = &mut methods[0];
 		method.name = atom("print");
 		method.func = Some(on_print);
 		method.params = 0;
 
-		let mut method = &mut methods[1];
+		let method = &mut methods[1];
 		method.name = atom("add_year");
 		method.func = Some(on_add_year);
 		method.params = 1;
@@ -122,12 +123,12 @@ impl sciter::om::Passport for Object {
 
 		let mut props = Box::new(ObjectProps::default());
 
-		let mut prop = &mut props[0];
+		let prop = &mut props[0];
 		prop.name = atom("age");
 		prop.getter = Some(on_get_age);
 		prop.setter = Some(on_set_age);
 
-		let mut prop = &mut props[1];
+		let prop = &mut props[1];
 		prop.name = atom("name");
 		prop.getter = Some(on_get_name);
 		prop.setter = Some(on_set_name);
@@ -144,7 +145,6 @@ impl sciter::om::Passport for Object {
 		Box::leak(pst)
 	}
 }
-
 
 #[derive(Debug)]
 struct Handler {
@@ -181,7 +181,7 @@ fn main() {
 	let object2 = sciter::om::IAssetRef::from(object2);
 	let ptr = object2.as_ptr();
 	let psp = object2.get_passport();
-	println!{"asset {:?} psp {:?}", ptr, psp as *const _};
+	println! {"asset {:?} psp {:?}", ptr, psp as *const _};
 	println!("asset: {:?}", object2);
 
 	let handler = Handler { asset: object2 };

--- a/examples/video.rs
+++ b/examples/video.rs
@@ -3,8 +3,8 @@
 extern crate sciter;
 
 use sciter::dom::event::*;
-use sciter::{Element, HELEMENT};
-
+use sciter::{Element, EVENT_GROUPS, HELEMENT, PHASE_MASK};
+use sciter::dom::BEHAVIOR_EVENTS;
 use sciter::video::{fragmented_video_destination, AssetPtr};
 
 struct VideoGen {

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "sciter-serde"
 version = "0.3.2"
+edition = "2024"
 description = "Serde support for Sciter engine."
 keywords = ["serde", "gui", "gtk", "opengl", "skia"]
 categories = ["gui", "web-programming", "rendering::graphics-api", "api-bindings"]

--- a/src/capi/scapi.rs
+++ b/src/capi/scapi.rs
@@ -2,273 +2,305 @@
 
 #![allow(non_snake_case, non_camel_case_types)]
 
-use capi::sctypes::*;
-use capi::scdef::*;
-use capi::scdom::*;
-use capi::scvalue::*;
-use capi::sctiscript::{HVM, tiscript_value, tiscript_native_interface};
-use capi::scbehavior::*;
-use capi::scgraphics::SciterGraphicsAPI;
-use capi::screquest::{SciterRequestAPI, HREQUEST, REQUEST_PARAM};
-use capi::scmsg::{SCITER_X_MSG};
-use capi::scom::{som_asset_t, som_atom_t};
-
+use crate::capi::scbehavior::*;
+use crate::capi::scdef::*;
+use crate::capi::scdom::*;
+use crate::capi::scgraphics::SciterGraphicsAPI;
+use crate::capi::scmsg::SCITER_X_MSG;
+use crate::capi::scom::{som_asset_t, som_atom_t};
+use crate::capi::screquest::{HREQUEST, REQUEST_PARAM, SciterRequestAPI};
+use crate::capi::sctiscript::{HVM, tiscript_native_interface, tiscript_value};
+use crate::capi::sctypes::*;
+use crate::capi::scvalue::*;
 
 /// Sciter API functions.
 #[repr(C)]
 #[allow(missing_docs)]
 #[doc(hidden)]
-pub struct ISciterAPI
-{
+pub struct ISciterAPI {
 	pub version: UINT,
 
-	pub SciterClassName: extern "system" fn () -> LPCWSTR,
-	pub SciterVersion: extern "system" fn (major: BOOL) -> UINT,
+	pub SciterClassName: extern "system" fn() -> LPCWSTR,
+	pub SciterVersion: extern "system" fn(major: BOOL) -> UINT,
 
-	pub SciterDataReady: extern "system" fn (hwnd: HWINDOW, uri: LPCWSTR, data: LPCBYTE, dataLength: UINT) -> BOOL,
-	pub SciterDataReadyAsync: extern "system" fn (hwnd: HWINDOW, uri: LPCWSTR, data: LPCBYTE, dataLength: UINT, requestId: HREQUEST) -> BOOL,
+	pub SciterDataReady: extern "system" fn(hwnd: HWINDOW, uri: LPCWSTR, data: LPCBYTE, dataLength: UINT) -> BOOL,
+	pub SciterDataReadyAsync: extern "system" fn(hwnd: HWINDOW, uri: LPCWSTR, data: LPCBYTE, dataLength: UINT, requestId: HREQUEST) -> BOOL,
 
-  // #ifdef WINDOWS
-  #[cfg_attr(not(all(windows, not(feature = "windowless"))), deprecated(note = "Windows only"))]
-	pub SciterProc: extern "system" fn (hwnd: HWINDOW, msg: UINT, wParam: WPARAM, lParam: LPARAM) -> LRESULT,
+	// #ifdef WINDOWS
 	#[cfg_attr(not(all(windows, not(feature = "windowless"))), deprecated(note = "Windows only"))]
-	pub SciterProcND: extern "system" fn (hwnd: HWINDOW, msg: UINT, wParam: WPARAM, lParam: LPARAM, pbHandled: * mut BOOL) -> LRESULT,
-  // #endif
-
-	pub SciterLoadFile: extern "system" fn (hWndSciter: HWINDOW, filename: LPCWSTR) -> BOOL,
-
-	pub SciterLoadHtml: extern "system" fn (hWndSciter: HWINDOW, html: LPCBYTE, htmlSize: UINT, baseUrl: LPCWSTR) -> BOOL,
-	pub SciterSetCallback: extern "system" fn (hWndSciter: HWINDOW, cb: SciterHostCallback, cbParam: LPVOID) -> VOID,
-	pub SciterSetMasterCSS: extern "system" fn (utf8: LPCBYTE, numBytes: UINT) -> BOOL,
-	pub SciterAppendMasterCSS: extern "system" fn (utf8: LPCBYTE, numBytes: UINT) -> BOOL,
-	pub SciterSetCSS: extern "system" fn (hWndSciter: HWINDOW, utf8: LPCBYTE, numBytes: UINT, baseUrl: LPCWSTR, mediaType: LPCWSTR) -> BOOL,
-	pub SciterSetMediaType: extern "system" fn (hWndSciter: HWINDOW, mediaType: LPCWSTR) -> BOOL,
-	pub SciterSetMediaVars: extern "system" fn (hWndSciter: HWINDOW, mediaVars: * const VALUE) -> BOOL,
-	pub SciterGetMinWidth: extern "system" fn (hWndSciter: HWINDOW) -> UINT,
-	pub SciterGetMinHeight: extern "system" fn (hWndSciter: HWINDOW, width: UINT) -> UINT,
-	pub SciterCall: extern "system" fn (hWnd: HWINDOW, functionName: LPCSTR, argc: UINT, argv: * const VALUE, retval: * mut VALUE) -> BOOL,
-	pub SciterEval: extern "system" fn (hwnd: HWINDOW, script: LPCWSTR, scriptLength: UINT, pretval: * mut VALUE) -> BOOL,
-	pub SciterUpdateWindow: extern "system" fn (hwnd: HWINDOW) -> VOID,
-
-  // #ifdef WINDOWS
-  #[cfg_attr(not(all(windows, not(feature = "windowless"))), deprecated(note = "Windows only"))]
-	pub SciterTranslateMessage: extern "system" fn (lpMsg: LPMSG) -> BOOL,
-  // #endif
-
-	pub SciterSetOption: extern "system" fn (hWnd: HWINDOW, option: SCITER_RT_OPTIONS, value: UINT_PTR) -> BOOL,
-	pub SciterGetPPI: extern "system" fn (hWndSciter: HWINDOW, px: * mut UINT, py: * mut UINT) -> VOID,
-	pub SciterGetViewExpando: extern "system" fn (hwnd: HWINDOW, pval: * mut VALUE) -> BOOL,
-
-  // #ifdef WINDOWS
-  #[cfg_attr(not(all(windows, not(feature = "windowless"))), deprecated(note = "Windows only"))]
-	pub SciterRenderD2D: extern "system" fn (hWndSciter: HWINDOW, prt: * mut ID2D1RenderTarget) -> BOOL,
+	pub SciterProc: extern "system" fn(hwnd: HWINDOW, msg: UINT, wParam: WPARAM, lParam: LPARAM) -> LRESULT,
 	#[cfg_attr(not(all(windows, not(feature = "windowless"))), deprecated(note = "Windows only"))]
-	pub SciterD2DFactory: extern "system" fn (ppf: * mut* mut ID2D1Factory) -> BOOL,
+	pub SciterProcND: extern "system" fn(hwnd: HWINDOW, msg: UINT, wParam: WPARAM, lParam: LPARAM, pbHandled: *mut BOOL) -> LRESULT,
+	// #endif
+	pub SciterLoadFile: extern "system" fn(hWndSciter: HWINDOW, filename: LPCWSTR) -> BOOL,
+
+	pub SciterLoadHtml: extern "system" fn(hWndSciter: HWINDOW, html: LPCBYTE, htmlSize: UINT, baseUrl: LPCWSTR) -> BOOL,
+	pub SciterSetCallback: extern "system" fn(hWndSciter: HWINDOW, cb: SciterHostCallback, cbParam: LPVOID) -> VOID,
+	pub SciterSetMasterCSS: extern "system" fn(utf8: LPCBYTE, numBytes: UINT) -> BOOL,
+	pub SciterAppendMasterCSS: extern "system" fn(utf8: LPCBYTE, numBytes: UINT) -> BOOL,
+	pub SciterSetCSS: extern "system" fn(hWndSciter: HWINDOW, utf8: LPCBYTE, numBytes: UINT, baseUrl: LPCWSTR, mediaType: LPCWSTR) -> BOOL,
+	pub SciterSetMediaType: extern "system" fn(hWndSciter: HWINDOW, mediaType: LPCWSTR) -> BOOL,
+	pub SciterSetMediaVars: extern "system" fn(hWndSciter: HWINDOW, mediaVars: *const VALUE) -> BOOL,
+	pub SciterGetMinWidth: extern "system" fn(hWndSciter: HWINDOW) -> UINT,
+	pub SciterGetMinHeight: extern "system" fn(hWndSciter: HWINDOW, width: UINT) -> UINT,
+	pub SciterCall: extern "system" fn(hWnd: HWINDOW, functionName: LPCSTR, argc: UINT, argv: *const VALUE, retval: *mut VALUE) -> BOOL,
+	pub SciterEval: extern "system" fn(hwnd: HWINDOW, script: LPCWSTR, scriptLength: UINT, pretval: *mut VALUE) -> BOOL,
+	pub SciterUpdateWindow: extern "system" fn(hwnd: HWINDOW) -> VOID,
+
+	// #ifdef WINDOWS
 	#[cfg_attr(not(all(windows, not(feature = "windowless"))), deprecated(note = "Windows only"))]
-	pub SciterDWFactory: extern "system" fn (ppf: * mut* mut IDWriteFactory) -> BOOL,
-  // #endif
+	pub SciterTranslateMessage: extern "system" fn(lpMsg: LPMSG) -> BOOL,
+	// #endif
+	pub SciterSetOption: extern "system" fn(hWnd: HWINDOW, option: SCITER_RT_OPTIONS, value: UINT_PTR) -> BOOL,
+	pub SciterGetPPI: extern "system" fn(hWndSciter: HWINDOW, px: *mut UINT, py: *mut UINT) -> VOID,
+	pub SciterGetViewExpando: extern "system" fn(hwnd: HWINDOW, pval: *mut VALUE) -> BOOL,
 
-	pub SciterGraphicsCaps: extern "system" fn (pcaps: LPUINT) -> BOOL,
-	pub SciterSetHomeURL: extern "system" fn (hWndSciter: HWINDOW, baseUrl: LPCWSTR) -> BOOL,
+	// #ifdef WINDOWS
+	#[cfg_attr(not(all(windows, not(feature = "windowless"))), deprecated(note = "Windows only"))]
+	pub SciterRenderD2D: extern "system" fn(hWndSciter: HWINDOW, prt: *mut ID2D1RenderTarget) -> BOOL,
+	#[cfg_attr(not(all(windows, not(feature = "windowless"))), deprecated(note = "Windows only"))]
+	pub SciterD2DFactory: extern "system" fn(ppf: *mut *mut ID2D1Factory) -> BOOL,
+	#[cfg_attr(not(all(windows, not(feature = "windowless"))), deprecated(note = "Windows only"))]
+	pub SciterDWFactory: extern "system" fn(ppf: *mut *mut IDWriteFactory) -> BOOL,
+	// #endif
+	pub SciterGraphicsCaps: extern "system" fn(pcaps: LPUINT) -> BOOL,
+	pub SciterSetHomeURL: extern "system" fn(hWndSciter: HWINDOW, baseUrl: LPCWSTR) -> BOOL,
 
-  // #if defined(OSX)
-	#[cfg_attr(not(all(target_os="macos", not(feature = "windowless"))), deprecated(note = "macOS only"))]
-	pub SciterCreateNSView: extern "system" fn (frame: LPRECT) -> HWINDOW, // returns NSView*
-  // #endif
+	// #if defined(OSX)
+	#[cfg_attr(not(all(target_os = "macos", not(feature = "windowless"))), deprecated(note = "macOS only"))]
+	pub SciterCreateNSView: extern "system" fn(frame: LPRECT) -> HWINDOW, // returns NSView*
+	// #endif
 
-  // #if defined(LINUX)
-	#[cfg_attr(not(all(target_os="linux", not(feature = "windowless"))), deprecated(note = "Linux only"))]
-	pub SciterCreateWidget: extern "system" fn (frame: LPRECT) -> HWINDOW, // returns GtkWidget
-  // #endif
-
+	// #if defined(LINUX)
+	#[cfg_attr(not(all(target_os = "linux", not(feature = "windowless"))), deprecated(note = "Linux only"))]
+	pub SciterCreateWidget: extern "system" fn(frame: LPRECT) -> HWINDOW, // returns GtkWidget
+	// #endif
 	#[cfg_attr(feature = "windowless", deprecated(note = "Windowed only"))]
-	pub SciterCreateWindow: extern "system" fn (creationFlags: UINT, frame: LPCRECT, delegate: * const SciterWindowDelegate, delegateParam: LPVOID, parent: HWINDOW) -> HWINDOW,
+	pub SciterCreateWindow: extern "system" fn(
+		creationFlags: UINT,
+		frame: LPCRECT,
+		delegate: *const SciterWindowDelegate,
+		delegateParam: LPVOID,
+		parent: HWINDOW,
+	) -> HWINDOW,
 
-	pub SciterSetupDebugOutput: extern "system" fn (hwndOrNull: HWINDOW, param: LPVOID, pfOutput: DEBUG_OUTPUT_PROC),
+	pub SciterSetupDebugOutput: extern "system" fn(hwndOrNull: HWINDOW, param: LPVOID, pfOutput: DEBUG_OUTPUT_PROC),
 
 	//|
 	//| DOM Element API
 	//|
-	pub Sciter_UseElement: extern "system" fn (he: HELEMENT) -> SCDOM_RESULT,
-	pub Sciter_UnuseElement: extern "system" fn (he: HELEMENT) -> SCDOM_RESULT,
-	pub SciterGetRootElement: extern "system" fn (hwnd: HWINDOW, phe: * mut HELEMENT) -> SCDOM_RESULT,
-	pub SciterGetFocusElement: extern "system" fn (hwnd: HWINDOW, phe: * mut HELEMENT) -> SCDOM_RESULT,
-	pub SciterFindElement: extern "system" fn (hwnd: HWINDOW, pt: POINT, phe: * mut HELEMENT) -> SCDOM_RESULT,
-	pub SciterGetChildrenCount: extern "system" fn (he: HELEMENT, count: * mut UINT) -> SCDOM_RESULT,
-	pub SciterGetNthChild: extern "system" fn (he: HELEMENT, n: UINT, phe: * mut HELEMENT) -> SCDOM_RESULT,
-	pub SciterGetParentElement: extern "system" fn (he: HELEMENT, p_parent_he: * mut HELEMENT) -> SCDOM_RESULT,
-	pub SciterGetElementHtmlCB: extern "system" fn (he: HELEMENT, outer: BOOL, rcv: LPCBYTE_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
-	pub SciterGetElementTextCB: extern "system" fn (he: HELEMENT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
-	pub SciterSetElementText: extern "system" fn (he: HELEMENT, utf16: LPCWSTR, length: UINT) -> SCDOM_RESULT,
-	pub SciterGetAttributeCount: extern "system" fn (he: HELEMENT, p_count: LPUINT) -> SCDOM_RESULT,
-	pub SciterGetNthAttributeNameCB: extern "system" fn (he: HELEMENT, n: UINT, rcv: LPCSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
-	pub SciterGetNthAttributeValueCB: extern "system" fn (he: HELEMENT, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
-	pub SciterGetAttributeByNameCB: extern "system" fn (he: HELEMENT, name: LPCSTR, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
-	pub SciterSetAttributeByName: extern "system" fn (he: HELEMENT, name: LPCSTR, value: LPCWSTR) -> SCDOM_RESULT,
-	pub SciterClearAttributes: extern "system" fn (he: HELEMENT) -> SCDOM_RESULT,
-	pub SciterGetElementIndex: extern "system" fn (he: HELEMENT, p_index: LPUINT) -> SCDOM_RESULT,
-	pub SciterGetElementType: extern "system" fn (he: HELEMENT, p_type: * mut LPCSTR) -> SCDOM_RESULT,
-	pub SciterGetElementTypeCB: extern "system" fn (he: HELEMENT, rcv: LPCSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
-	pub SciterGetStyleAttributeCB: extern "system" fn (he: HELEMENT, name: LPCSTR, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
-	pub SciterSetStyleAttribute: extern "system" fn (he: HELEMENT, name: LPCSTR, value: LPCWSTR) -> SCDOM_RESULT,
-	pub SciterGetElementLocation: extern "system" fn (he: HELEMENT, p_location: LPRECT, areas: UINT /*ELEMENT_AREAS*/) -> SCDOM_RESULT,
-	pub SciterScrollToView: extern "system" fn (he: HELEMENT, SciterScrollFlags: UINT) -> SCDOM_RESULT,
-	pub SciterUpdateElement: extern "system" fn (he: HELEMENT, andForceRender: BOOL) -> SCDOM_RESULT,
-	pub SciterRefreshElementArea: extern "system" fn (he: HELEMENT, rc: RECT) -> SCDOM_RESULT,
-	pub SciterSetCapture: extern "system" fn (he: HELEMENT) -> SCDOM_RESULT,
-	pub SciterReleaseCapture: extern "system" fn (he: HELEMENT) -> SCDOM_RESULT,
-	pub SciterGetElementHwnd: extern "system" fn (he: HELEMENT, p_hwnd: * mut HWINDOW, rootWindow: BOOL) -> SCDOM_RESULT,
-	pub SciterCombineURL: extern "system" fn (he: HELEMENT, szUrlBuffer: LPWSTR, UrlBufferSize: UINT) -> SCDOM_RESULT,
-	pub SciterSelectElements: extern "system" fn (he: HELEMENT, CSS_selectors: LPCSTR, callback: SciterElementCallback, param: LPVOID) -> SCDOM_RESULT,
-	pub SciterSelectElementsW: extern "system" fn (he: HELEMENT, CSS_selectors: LPCWSTR, callback: SciterElementCallback, param: LPVOID) -> SCDOM_RESULT,
-	pub SciterSelectParent: extern "system" fn (he: HELEMENT, selector: LPCSTR, depth: UINT, heFound: * mut HELEMENT) -> SCDOM_RESULT,
-	pub SciterSelectParentW: extern "system" fn (he: HELEMENT, selector: LPCWSTR, depth: UINT, heFound: * mut HELEMENT) -> SCDOM_RESULT,
-	pub SciterSetElementHtml: extern "system" fn (he: HELEMENT, html: * const BYTE, htmlLength: UINT, how: UINT) -> SCDOM_RESULT,
-	pub SciterGetElementUID: extern "system" fn (he: HELEMENT, puid: * mut UINT) -> SCDOM_RESULT,
-	pub SciterGetElementByUID: extern "system" fn (hwnd: HWINDOW, uid: UINT, phe: * mut HELEMENT) -> SCDOM_RESULT,
-	pub SciterShowPopup: extern "system" fn (hePopup: HELEMENT, heAnchor: HELEMENT, placement: UINT) -> SCDOM_RESULT,
-	pub SciterShowPopupAt: extern "system" fn (hePopup: HELEMENT, pos: POINT, placement: UINT) -> SCDOM_RESULT,
-	pub SciterHidePopup: extern "system" fn (he: HELEMENT) -> SCDOM_RESULT,
-	pub SciterGetElementState: extern "system" fn (he: HELEMENT, pstateBits: * mut UINT) -> SCDOM_RESULT,
-	pub SciterSetElementState: extern "system" fn (he: HELEMENT, stateBitsToSet: UINT, stateBitsToClear: UINT, updateView: BOOL) -> SCDOM_RESULT,
-	pub SciterCreateElement: extern "system" fn (tagname: LPCSTR, textOrNull: LPCWSTR, /*out*/ phe: * mut HELEMENT) -> SCDOM_RESULT,
-	pub SciterCloneElement: extern "system" fn (he: HELEMENT, /*out*/ phe: * mut HELEMENT) -> SCDOM_RESULT,
-	pub SciterInsertElement: extern "system" fn (he: HELEMENT, hparent: HELEMENT, index: UINT) -> SCDOM_RESULT,
-	pub SciterDetachElement: extern "system" fn (he: HELEMENT) -> SCDOM_RESULT,
-	pub SciterDeleteElement: extern "system" fn (he: HELEMENT) -> SCDOM_RESULT,
-	pub SciterSetTimer: extern "system" fn (he: HELEMENT, milliseconds: UINT, timer_id: UINT_PTR) -> SCDOM_RESULT,
-	pub SciterDetachEventHandler: extern "system" fn (he: HELEMENT, pep: ElementEventProc, tag: LPVOID) -> SCDOM_RESULT,
-	pub SciterAttachEventHandler: extern "system" fn (he: HELEMENT, pep: ElementEventProc, tag: LPVOID) -> SCDOM_RESULT,
-	pub SciterWindowAttachEventHandler: extern "system" fn (hwndLayout: HWINDOW, pep: ElementEventProc, tag: LPVOID, subscription: UINT) -> SCDOM_RESULT,
-	pub SciterWindowDetachEventHandler: extern "system" fn (hwndLayout: HWINDOW, pep: ElementEventProc, tag: LPVOID) -> SCDOM_RESULT,
-	pub SciterSendEvent: extern "system" fn (he: HELEMENT, appEventCode: UINT, heSource: HELEMENT, reason: UINT_PTR, /*out*/ handled: * mut BOOL) -> SCDOM_RESULT,
-	pub SciterPostEvent: extern "system" fn (he: HELEMENT, appEventCode: UINT, heSource: HELEMENT, reason: UINT_PTR) -> SCDOM_RESULT,
-	pub SciterCallBehaviorMethod: extern "system" fn (he: HELEMENT, params: * const METHOD_PARAMS) -> SCDOM_RESULT,
-	pub SciterRequestElementData: extern "system" fn (he: HELEMENT, url: LPCWSTR, dataType: UINT, initiator: HELEMENT) -> SCDOM_RESULT,
-	pub SciterHttpRequest: extern "system" fn (he: HELEMENT, url: LPCWSTR, dataType: UINT, requestType: UINT, requestParams: * const REQUEST_PARAM, nParams: UINT) -> SCDOM_RESULT,
-	pub SciterGetScrollInfo: extern "system" fn (he: HELEMENT, scrollPos: LPPOINT, viewRect: LPRECT, contentSize: LPSIZE) -> SCDOM_RESULT,
-	pub SciterSetScrollPos: extern "system" fn (he: HELEMENT, scrollPos: POINT, smooth: BOOL) -> SCDOM_RESULT,
-	pub SciterGetElementIntrinsicWidths: extern "system" fn (he: HELEMENT, pMinWidth: * mut INT, pMaxWidth: * mut INT) -> SCDOM_RESULT,
-	pub SciterGetElementIntrinsicHeight: extern "system" fn (he: HELEMENT, forWidth: INT, pHeight: * mut INT) -> SCDOM_RESULT,
-	pub SciterIsElementVisible: extern "system" fn (he: HELEMENT, pVisible: * mut BOOL) -> SCDOM_RESULT,
-	pub SciterIsElementEnabled: extern "system" fn (he: HELEMENT, pEnabled: * mut BOOL) -> SCDOM_RESULT,
-	pub SciterSortElements: extern "system" fn (he: HELEMENT, firstIndex: UINT, lastIndex: UINT, cmpFunc: * mut ELEMENT_COMPARATOR, cmpFuncParam: LPVOID) -> SCDOM_RESULT,
-	pub SciterSwapElements: extern "system" fn (he1: HELEMENT, he2: HELEMENT) -> SCDOM_RESULT,
-	pub SciterTraverseUIEvent: extern "system" fn (evt: UINT, eventCtlStruct: LPVOID, bOutProcessed: * mut BOOL) -> SCDOM_RESULT,
-	pub SciterCallScriptingMethod: extern "system" fn (he: HELEMENT, name: LPCSTR, argv: * const VALUE, argc: UINT, retval: * mut VALUE) -> SCDOM_RESULT,
-	pub SciterCallScriptingFunction: extern "system" fn (he: HELEMENT, name: LPCSTR, argv: * const VALUE, argc: UINT, retval: * mut VALUE) -> SCDOM_RESULT,
-	pub SciterEvalElementScript: extern "system" fn (he: HELEMENT, script: LPCWSTR, scriptLength: UINT, retval: * mut VALUE) -> SCDOM_RESULT,
-	pub SciterAttachHwndToElement: extern "system" fn (he: HELEMENT, hwnd: HWINDOW) -> SCDOM_RESULT,
-	pub SciterControlGetType: extern "system" fn (he: HELEMENT, /*CTL_TYPE*/ pType: * mut UINT) -> SCDOM_RESULT,
-	pub SciterGetValue: extern "system" fn (he: HELEMENT, pval: * mut VALUE) -> SCDOM_RESULT,
-	pub SciterSetValue: extern "system" fn (he: HELEMENT, pval: * const VALUE) -> SCDOM_RESULT,
-	pub SciterGetExpando: extern "system" fn (he: HELEMENT, pval: * mut VALUE, forceCreation: BOOL) -> SCDOM_RESULT,
+	pub Sciter_UseElement: extern "system" fn(he: HELEMENT) -> SCDOM_RESULT,
+	pub Sciter_UnuseElement: extern "system" fn(he: HELEMENT) -> SCDOM_RESULT,
+	pub SciterGetRootElement: extern "system" fn(hwnd: HWINDOW, phe: *mut HELEMENT) -> SCDOM_RESULT,
+	pub SciterGetFocusElement: extern "system" fn(hwnd: HWINDOW, phe: *mut HELEMENT) -> SCDOM_RESULT,
+	pub SciterFindElement: extern "system" fn(hwnd: HWINDOW, pt: POINT, phe: *mut HELEMENT) -> SCDOM_RESULT,
+	pub SciterGetChildrenCount: extern "system" fn(he: HELEMENT, count: *mut UINT) -> SCDOM_RESULT,
+	pub SciterGetNthChild: extern "system" fn(he: HELEMENT, n: UINT, phe: *mut HELEMENT) -> SCDOM_RESULT,
+	pub SciterGetParentElement: extern "system" fn(he: HELEMENT, p_parent_he: *mut HELEMENT) -> SCDOM_RESULT,
+	pub SciterGetElementHtmlCB: extern "system" fn(he: HELEMENT, outer: BOOL, rcv: LPCBYTE_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
+	pub SciterGetElementTextCB: extern "system" fn(he: HELEMENT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
+	pub SciterSetElementText: extern "system" fn(he: HELEMENT, utf16: LPCWSTR, length: UINT) -> SCDOM_RESULT,
+	pub SciterGetAttributeCount: extern "system" fn(he: HELEMENT, p_count: LPUINT) -> SCDOM_RESULT,
+	pub SciterGetNthAttributeNameCB: extern "system" fn(he: HELEMENT, n: UINT, rcv: LPCSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
+	pub SciterGetNthAttributeValueCB: extern "system" fn(he: HELEMENT, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
+	pub SciterGetAttributeByNameCB: extern "system" fn(he: HELEMENT, name: LPCSTR, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
+	pub SciterSetAttributeByName: extern "system" fn(he: HELEMENT, name: LPCSTR, value: LPCWSTR) -> SCDOM_RESULT,
+	pub SciterClearAttributes: extern "system" fn(he: HELEMENT) -> SCDOM_RESULT,
+	pub SciterGetElementIndex: extern "system" fn(he: HELEMENT, p_index: LPUINT) -> SCDOM_RESULT,
+	pub SciterGetElementType: extern "system" fn(he: HELEMENT, p_type: *mut LPCSTR) -> SCDOM_RESULT,
+	pub SciterGetElementTypeCB: extern "system" fn(he: HELEMENT, rcv: LPCSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
+	pub SciterGetStyleAttributeCB: extern "system" fn(he: HELEMENT, name: LPCSTR, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
+	pub SciterSetStyleAttribute: extern "system" fn(he: HELEMENT, name: LPCSTR, value: LPCWSTR) -> SCDOM_RESULT,
+	pub SciterGetElementLocation: extern "system" fn(he: HELEMENT, p_location: LPRECT, areas: UINT /*ELEMENT_AREAS*/) -> SCDOM_RESULT,
+	pub SciterScrollToView: extern "system" fn(he: HELEMENT, SciterScrollFlags: UINT) -> SCDOM_RESULT,
+	pub SciterUpdateElement: extern "system" fn(he: HELEMENT, andForceRender: BOOL) -> SCDOM_RESULT,
+	pub SciterRefreshElementArea: extern "system" fn(he: HELEMENT, rc: RECT) -> SCDOM_RESULT,
+	pub SciterSetCapture: extern "system" fn(he: HELEMENT) -> SCDOM_RESULT,
+	pub SciterReleaseCapture: extern "system" fn(he: HELEMENT) -> SCDOM_RESULT,
+	pub SciterGetElementHwnd: extern "system" fn(he: HELEMENT, p_hwnd: *mut HWINDOW, rootWindow: BOOL) -> SCDOM_RESULT,
+	pub SciterCombineURL: extern "system" fn(he: HELEMENT, szUrlBuffer: LPWSTR, UrlBufferSize: UINT) -> SCDOM_RESULT,
+	pub SciterSelectElements:
+		extern "system" fn(he: HELEMENT, CSS_selectors: LPCSTR, callback: SciterElementCallback, param: LPVOID) -> SCDOM_RESULT,
+	pub SciterSelectElementsW:
+		extern "system" fn(he: HELEMENT, CSS_selectors: LPCWSTR, callback: SciterElementCallback, param: LPVOID) -> SCDOM_RESULT,
+	pub SciterSelectParent: extern "system" fn(he: HELEMENT, selector: LPCSTR, depth: UINT, heFound: *mut HELEMENT) -> SCDOM_RESULT,
+	pub SciterSelectParentW: extern "system" fn(he: HELEMENT, selector: LPCWSTR, depth: UINT, heFound: *mut HELEMENT) -> SCDOM_RESULT,
+	pub SciterSetElementHtml: extern "system" fn(he: HELEMENT, html: *const BYTE, htmlLength: UINT, how: UINT) -> SCDOM_RESULT,
+	pub SciterGetElementUID: extern "system" fn(he: HELEMENT, puid: *mut UINT) -> SCDOM_RESULT,
+	pub SciterGetElementByUID: extern "system" fn(hwnd: HWINDOW, uid: UINT, phe: *mut HELEMENT) -> SCDOM_RESULT,
+	pub SciterShowPopup: extern "system" fn(hePopup: HELEMENT, heAnchor: HELEMENT, placement: UINT) -> SCDOM_RESULT,
+	pub SciterShowPopupAt: extern "system" fn(hePopup: HELEMENT, pos: POINT, placement: UINT) -> SCDOM_RESULT,
+	pub SciterHidePopup: extern "system" fn(he: HELEMENT) -> SCDOM_RESULT,
+	pub SciterGetElementState: extern "system" fn(he: HELEMENT, pstateBits: *mut UINT) -> SCDOM_RESULT,
+	pub SciterSetElementState:
+		extern "system" fn(he: HELEMENT, stateBitsToSet: UINT, stateBitsToClear: UINT, updateView: BOOL) -> SCDOM_RESULT,
+	pub SciterCreateElement: extern "system" fn(tagname: LPCSTR, textOrNull: LPCWSTR, /*out*/ phe: *mut HELEMENT) -> SCDOM_RESULT,
+	pub SciterCloneElement: extern "system" fn(he: HELEMENT, /*out*/ phe: *mut HELEMENT) -> SCDOM_RESULT,
+	pub SciterInsertElement: extern "system" fn(he: HELEMENT, hparent: HELEMENT, index: UINT) -> SCDOM_RESULT,
+	pub SciterDetachElement: extern "system" fn(he: HELEMENT) -> SCDOM_RESULT,
+	pub SciterDeleteElement: extern "system" fn(he: HELEMENT) -> SCDOM_RESULT,
+	pub SciterSetTimer: extern "system" fn(he: HELEMENT, milliseconds: UINT, timer_id: UINT_PTR) -> SCDOM_RESULT,
+	pub SciterDetachEventHandler: extern "system" fn(he: HELEMENT, pep: ElementEventProc, tag: LPVOID) -> SCDOM_RESULT,
+	pub SciterAttachEventHandler: extern "system" fn(he: HELEMENT, pep: ElementEventProc, tag: LPVOID) -> SCDOM_RESULT,
+	pub SciterWindowAttachEventHandler:
+		extern "system" fn(hwndLayout: HWINDOW, pep: ElementEventProc, tag: LPVOID, subscription: UINT) -> SCDOM_RESULT,
+	pub SciterWindowDetachEventHandler: extern "system" fn(hwndLayout: HWINDOW, pep: ElementEventProc, tag: LPVOID) -> SCDOM_RESULT,
+	pub SciterSendEvent: extern "system" fn(
+		he: HELEMENT,
+		appEventCode: UINT,
+		heSource: HELEMENT,
+		reason: UINT_PTR,
+		/*out*/ handled: *mut BOOL,
+	) -> SCDOM_RESULT,
+	pub SciterPostEvent: extern "system" fn(he: HELEMENT, appEventCode: UINT, heSource: HELEMENT, reason: UINT_PTR) -> SCDOM_RESULT,
+	pub SciterCallBehaviorMethod: extern "system" fn(he: HELEMENT, params: *const METHOD_PARAMS) -> SCDOM_RESULT,
+	pub SciterRequestElementData: extern "system" fn(he: HELEMENT, url: LPCWSTR, dataType: UINT, initiator: HELEMENT) -> SCDOM_RESULT,
+	pub SciterHttpRequest: extern "system" fn(
+		he: HELEMENT,
+		url: LPCWSTR,
+		dataType: UINT,
+		requestType: UINT,
+		requestParams: *const REQUEST_PARAM,
+		nParams: UINT,
+	) -> SCDOM_RESULT,
+	pub SciterGetScrollInfo: extern "system" fn(he: HELEMENT, scrollPos: LPPOINT, viewRect: LPRECT, contentSize: LPSIZE) -> SCDOM_RESULT,
+	pub SciterSetScrollPos: extern "system" fn(he: HELEMENT, scrollPos: POINT, smooth: BOOL) -> SCDOM_RESULT,
+	pub SciterGetElementIntrinsicWidths: extern "system" fn(he: HELEMENT, pMinWidth: *mut INT, pMaxWidth: *mut INT) -> SCDOM_RESULT,
+	pub SciterGetElementIntrinsicHeight: extern "system" fn(he: HELEMENT, forWidth: INT, pHeight: *mut INT) -> SCDOM_RESULT,
+	pub SciterIsElementVisible: extern "system" fn(he: HELEMENT, pVisible: *mut BOOL) -> SCDOM_RESULT,
+	pub SciterIsElementEnabled: extern "system" fn(he: HELEMENT, pEnabled: *mut BOOL) -> SCDOM_RESULT,
+	pub SciterSortElements: extern "system" fn(
+		he: HELEMENT,
+		firstIndex: UINT,
+		lastIndex: UINT,
+		cmpFunc: *mut ELEMENT_COMPARATOR,
+		cmpFuncParam: LPVOID,
+	) -> SCDOM_RESULT,
+	pub SciterSwapElements: extern "system" fn(he1: HELEMENT, he2: HELEMENT) -> SCDOM_RESULT,
+	pub SciterTraverseUIEvent: extern "system" fn(evt: UINT, eventCtlStruct: LPVOID, bOutProcessed: *mut BOOL) -> SCDOM_RESULT,
+	pub SciterCallScriptingMethod:
+		extern "system" fn(he: HELEMENT, name: LPCSTR, argv: *const VALUE, argc: UINT, retval: *mut VALUE) -> SCDOM_RESULT,
+	pub SciterCallScriptingFunction:
+		extern "system" fn(he: HELEMENT, name: LPCSTR, argv: *const VALUE, argc: UINT, retval: *mut VALUE) -> SCDOM_RESULT,
+	pub SciterEvalElementScript: extern "system" fn(he: HELEMENT, script: LPCWSTR, scriptLength: UINT, retval: *mut VALUE) -> SCDOM_RESULT,
+	pub SciterAttachHwndToElement: extern "system" fn(he: HELEMENT, hwnd: HWINDOW) -> SCDOM_RESULT,
+	pub SciterControlGetType: extern "system" fn(he: HELEMENT, /*CTL_TYPE*/ pType: *mut UINT) -> SCDOM_RESULT,
+	pub SciterGetValue: extern "system" fn(he: HELEMENT, pval: *mut VALUE) -> SCDOM_RESULT,
+	pub SciterSetValue: extern "system" fn(he: HELEMENT, pval: *const VALUE) -> SCDOM_RESULT,
+	pub SciterGetExpando: extern "system" fn(he: HELEMENT, pval: *mut VALUE, forceCreation: BOOL) -> SCDOM_RESULT,
 
-	#[deprecated(since="Sciter 4.4.3.24", note="TIScript native API is gone, use SOM instead.")]
-	pub SciterGetObject: extern "system" fn (he: HELEMENT, pval: * mut tiscript_value, forceCreation: BOOL) -> SCDOM_RESULT,
+	#[deprecated(since = "Sciter 4.4.3.24", note = "TIScript native API is gone, use SOM instead.")]
+	pub SciterGetObject: extern "system" fn(he: HELEMENT, pval: *mut tiscript_value, forceCreation: BOOL) -> SCDOM_RESULT,
 
-	#[deprecated(since="Sciter 4.4.3.24", note="TIScript native API is gone, use SOM instead.")]
-	pub SciterGetElementNamespace: extern "system" fn (he: HELEMENT, pval: * mut tiscript_value) -> SCDOM_RESULT,
+	#[deprecated(since = "Sciter 4.4.3.24", note = "TIScript native API is gone, use SOM instead.")]
+	pub SciterGetElementNamespace: extern "system" fn(he: HELEMENT, pval: *mut tiscript_value) -> SCDOM_RESULT,
 
-	pub SciterGetHighlightedElement: extern "system" fn (hwnd: HWINDOW, phe: * mut HELEMENT) -> SCDOM_RESULT,
-	pub SciterSetHighlightedElement: extern "system" fn (hwnd: HWINDOW, he: HELEMENT) -> SCDOM_RESULT,
+	pub SciterGetHighlightedElement: extern "system" fn(hwnd: HWINDOW, phe: *mut HELEMENT) -> SCDOM_RESULT,
+	pub SciterSetHighlightedElement: extern "system" fn(hwnd: HWINDOW, he: HELEMENT) -> SCDOM_RESULT,
 	//|
 	//| DOM Node API
 	//|
-	pub SciterNodeAddRef: extern "system" fn (hn: HNODE) -> SCDOM_RESULT,
-	pub SciterNodeRelease: extern "system" fn (hn: HNODE) -> SCDOM_RESULT,
-	pub SciterNodeCastFromElement: extern "system" fn (he: HELEMENT, phn: * mut HNODE) -> SCDOM_RESULT,
-	pub SciterNodeCastToElement: extern "system" fn (hn: HNODE, he: * mut HELEMENT) -> SCDOM_RESULT,
-	pub SciterNodeFirstChild: extern "system" fn (hn: HNODE, phn: * mut HNODE) -> SCDOM_RESULT,
-	pub SciterNodeLastChild: extern "system" fn (hn: HNODE, phn: * mut HNODE) -> SCDOM_RESULT,
-	pub SciterNodeNextSibling: extern "system" fn (hn: HNODE, phn: * mut HNODE) -> SCDOM_RESULT,
-	pub SciterNodePrevSibling: extern "system" fn (hn: HNODE, phn: * mut HNODE) -> SCDOM_RESULT,
-	pub SciterNodeParent: extern "system" fn (hnode: HNODE, pheParent: * mut HELEMENT) -> SCDOM_RESULT,
-	pub SciterNodeNthChild: extern "system" fn (hnode: HNODE, n: UINT, phn: * mut HNODE) -> SCDOM_RESULT,
-	pub SciterNodeChildrenCount: extern "system" fn (hnode: HNODE, pn: * mut UINT) -> SCDOM_RESULT,
-	pub SciterNodeType: extern "system" fn (hnode: HNODE, pNodeType: * mut UINT /*NODE_TYPE*/) -> SCDOM_RESULT,
-	pub SciterNodeGetText: extern "system" fn (hnode: HNODE, rcv: * mut LPCWSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
-	pub SciterNodeSetText: extern "system" fn (hnode: HNODE, text: LPCWSTR, textLength: UINT) -> SCDOM_RESULT,
-	pub SciterNodeInsert: extern "system" fn (hnode: HNODE, how: UINT /*NODE_INS_TARGET*/, what: HNODE) -> SCDOM_RESULT,
-	pub SciterNodeRemove: extern "system" fn (hnode: HNODE, finalize: BOOL) -> SCDOM_RESULT,
-	pub SciterCreateTextNode: extern "system" fn (text: LPCWSTR, textLength: UINT, phnode: * mut HNODE) -> SCDOM_RESULT,
-	pub SciterCreateCommentNode: extern "system" fn (text: LPCWSTR, textLength: UINT, phnode: * mut HNODE) -> SCDOM_RESULT,
+	pub SciterNodeAddRef: extern "system" fn(hn: HNODE) -> SCDOM_RESULT,
+	pub SciterNodeRelease: extern "system" fn(hn: HNODE) -> SCDOM_RESULT,
+	pub SciterNodeCastFromElement: extern "system" fn(he: HELEMENT, phn: *mut HNODE) -> SCDOM_RESULT,
+	pub SciterNodeCastToElement: extern "system" fn(hn: HNODE, he: *mut HELEMENT) -> SCDOM_RESULT,
+	pub SciterNodeFirstChild: extern "system" fn(hn: HNODE, phn: *mut HNODE) -> SCDOM_RESULT,
+	pub SciterNodeLastChild: extern "system" fn(hn: HNODE, phn: *mut HNODE) -> SCDOM_RESULT,
+	pub SciterNodeNextSibling: extern "system" fn(hn: HNODE, phn: *mut HNODE) -> SCDOM_RESULT,
+	pub SciterNodePrevSibling: extern "system" fn(hn: HNODE, phn: *mut HNODE) -> SCDOM_RESULT,
+	pub SciterNodeParent: extern "system" fn(hnode: HNODE, pheParent: *mut HELEMENT) -> SCDOM_RESULT,
+	pub SciterNodeNthChild: extern "system" fn(hnode: HNODE, n: UINT, phn: *mut HNODE) -> SCDOM_RESULT,
+	pub SciterNodeChildrenCount: extern "system" fn(hnode: HNODE, pn: *mut UINT) -> SCDOM_RESULT,
+	pub SciterNodeType: extern "system" fn(hnode: HNODE, pNodeType: *mut UINT /*NODE_TYPE*/) -> SCDOM_RESULT,
+	pub SciterNodeGetText: extern "system" fn(hnode: HNODE, rcv: *mut LPCWSTR_RECEIVER, rcv_param: LPVOID) -> SCDOM_RESULT,
+	pub SciterNodeSetText: extern "system" fn(hnode: HNODE, text: LPCWSTR, textLength: UINT) -> SCDOM_RESULT,
+	pub SciterNodeInsert: extern "system" fn(hnode: HNODE, how: UINT /*NODE_INS_TARGET*/, what: HNODE) -> SCDOM_RESULT,
+	pub SciterNodeRemove: extern "system" fn(hnode: HNODE, finalize: BOOL) -> SCDOM_RESULT,
+	pub SciterCreateTextNode: extern "system" fn(text: LPCWSTR, textLength: UINT, phnode: *mut HNODE) -> SCDOM_RESULT,
+	pub SciterCreateCommentNode: extern "system" fn(text: LPCWSTR, textLength: UINT, phnode: *mut HNODE) -> SCDOM_RESULT,
 	//|
 	//| Value API
 	//|
-	pub ValueInit: extern "system" fn (pval: * mut VALUE) -> VALUE_RESULT,
-	pub ValueClear: extern "system" fn (pval: * mut VALUE) -> VALUE_RESULT,
-	pub ValueCompare: extern "system" fn (pval1: * const VALUE, pval2: * const VALUE) -> VALUE_RESULT,
-	pub ValueCopy: extern "system" fn (pdst: * mut VALUE, psrc: * const VALUE) -> VALUE_RESULT,
-	pub ValueIsolate: extern "system" fn (pdst: * mut VALUE) -> VALUE_RESULT,
-	pub ValueType: extern "system" fn (pval: * const VALUE, pType: * mut UINT, pUnits: * mut UINT) -> VALUE_RESULT,
-	pub ValueStringData: extern "system" fn (pval: * const VALUE, pChars: * mut LPCWSTR, pNumChars: * mut UINT) -> VALUE_RESULT,
-	pub ValueStringDataSet: extern "system" fn (pval: * mut VALUE, chars: LPCWSTR, numChars: UINT, units: UINT) -> VALUE_RESULT,
-	pub ValueIntData: extern "system" fn (pval: * const VALUE, pData: * mut INT) -> VALUE_RESULT,
-	pub ValueIntDataSet: extern "system" fn (pval: * mut VALUE, data: INT, vtype: UINT, units: UINT) -> VALUE_RESULT,
-	pub ValueInt64Data: extern "system" fn (pval: * const VALUE, pData: * mut INT64) -> VALUE_RESULT,
-	pub ValueInt64DataSet: extern "system" fn (pval: * mut VALUE, data: INT64, vtype: UINT, units: UINT) -> VALUE_RESULT,
-	pub ValueFloatData: extern "system" fn (pval: * const VALUE, pData: * mut FLOAT_VALUE) -> VALUE_RESULT,
-	pub ValueFloatDataSet: extern "system" fn (pval: * mut VALUE, data: FLOAT_VALUE, vtype: UINT, units: UINT) -> VALUE_RESULT,
-	pub ValueBinaryData: extern "system" fn (pval: * const VALUE, pBytes: * mut LPCBYTE, pnBytes: * mut UINT) -> VALUE_RESULT,
-	pub ValueBinaryDataSet: extern "system" fn (pval: * mut VALUE, pBytes: LPCBYTE, nBytes: UINT, vtype: UINT, units: UINT) -> VALUE_RESULT,
-	pub ValueElementsCount: extern "system" fn (pval: * const VALUE, pn: * mut INT) -> VALUE_RESULT,
-	pub ValueNthElementValue: extern "system" fn (pval: * const VALUE, n: INT, pretval: * mut VALUE) -> VALUE_RESULT,
-	pub ValueNthElementValueSet: extern "system" fn (pval: * mut VALUE, n: INT, pval_to_set: * const VALUE) -> VALUE_RESULT,
-	pub ValueNthElementKey: extern "system" fn (pval: * const VALUE, n: INT, pretval: * mut VALUE) -> VALUE_RESULT,
-	pub ValueEnumElements: extern "system" fn (pval: * const VALUE, penum: KeyValueCallback, param: LPVOID) -> VALUE_RESULT,
-	pub ValueSetValueToKey: extern "system" fn (pval: * mut VALUE, pkey: * const VALUE, pval_to_set: * const VALUE) -> VALUE_RESULT,
-	pub ValueGetValueOfKey: extern "system" fn (pval: * const VALUE, pkey: * const VALUE, pretval: * mut VALUE) -> VALUE_RESULT,
-	pub ValueToString: extern "system" fn (pval: * mut VALUE, how: VALUE_STRING_CVT_TYPE) -> VALUE_RESULT,
-	pub ValueFromString: extern "system" fn (pval: * mut VALUE, str: LPCWSTR, strLength: UINT, how: VALUE_STRING_CVT_TYPE) -> UINT,
-	pub ValueInvoke: extern "system" fn (pval: * const VALUE, pthis: * mut VALUE, argc: UINT, argv: * const VALUE, pretval: * mut VALUE, url: LPCWSTR) -> VALUE_RESULT,
-	pub ValueNativeFunctorSet: extern "system" fn (pval: * mut VALUE, pinvoke: NATIVE_FUNCTOR_INVOKE, prelease: NATIVE_FUNCTOR_RELEASE, tag: LPVOID) -> VALUE_RESULT,
-	pub ValueIsNativeFunctor: extern "system" fn (pval: * const VALUE) -> BOOL,
+	pub ValueInit: extern "system" fn(pval: *mut VALUE) -> VALUE_RESULT,
+	pub ValueClear: extern "system" fn(pval: *mut VALUE) -> VALUE_RESULT,
+	pub ValueCompare: extern "system" fn(pval1: *const VALUE, pval2: *const VALUE) -> VALUE_RESULT,
+	pub ValueCopy: extern "system" fn(pdst: *mut VALUE, psrc: *const VALUE) -> VALUE_RESULT,
+	pub ValueIsolate: extern "system" fn(pdst: *mut VALUE) -> VALUE_RESULT,
+	pub ValueType: extern "system" fn(pval: *const VALUE, pType: *mut UINT, pUnits: *mut UINT) -> VALUE_RESULT,
+	pub ValueStringData: extern "system" fn(pval: *const VALUE, pChars: *mut LPCWSTR, pNumChars: *mut UINT) -> VALUE_RESULT,
+	pub ValueStringDataSet: extern "system" fn(pval: *mut VALUE, chars: LPCWSTR, numChars: UINT, units: UINT) -> VALUE_RESULT,
+	pub ValueIntData: extern "system" fn(pval: *const VALUE, pData: *mut INT) -> VALUE_RESULT,
+	pub ValueIntDataSet: extern "system" fn(pval: *mut VALUE, data: INT, vtype: UINT, units: UINT) -> VALUE_RESULT,
+	pub ValueInt64Data: extern "system" fn(pval: *const VALUE, pData: *mut INT64) -> VALUE_RESULT,
+	pub ValueInt64DataSet: extern "system" fn(pval: *mut VALUE, data: INT64, vtype: UINT, units: UINT) -> VALUE_RESULT,
+	pub ValueFloatData: extern "system" fn(pval: *const VALUE, pData: *mut FLOAT_VALUE) -> VALUE_RESULT,
+	pub ValueFloatDataSet: extern "system" fn(pval: *mut VALUE, data: FLOAT_VALUE, vtype: UINT, units: UINT) -> VALUE_RESULT,
+	pub ValueBinaryData: extern "system" fn(pval: *const VALUE, pBytes: *mut LPCBYTE, pnBytes: *mut UINT) -> VALUE_RESULT,
+	pub ValueBinaryDataSet: extern "system" fn(pval: *mut VALUE, pBytes: LPCBYTE, nBytes: UINT, vtype: UINT, units: UINT) -> VALUE_RESULT,
+	pub ValueElementsCount: extern "system" fn(pval: *const VALUE, pn: *mut INT) -> VALUE_RESULT,
+	pub ValueNthElementValue: extern "system" fn(pval: *const VALUE, n: INT, pretval: *mut VALUE) -> VALUE_RESULT,
+	pub ValueNthElementValueSet: extern "system" fn(pval: *mut VALUE, n: INT, pval_to_set: *const VALUE) -> VALUE_RESULT,
+	pub ValueNthElementKey: extern "system" fn(pval: *const VALUE, n: INT, pretval: *mut VALUE) -> VALUE_RESULT,
+	pub ValueEnumElements: extern "system" fn(pval: *const VALUE, penum: KeyValueCallback, param: LPVOID) -> VALUE_RESULT,
+	pub ValueSetValueToKey: extern "system" fn(pval: *mut VALUE, pkey: *const VALUE, pval_to_set: *const VALUE) -> VALUE_RESULT,
+	pub ValueGetValueOfKey: extern "system" fn(pval: *const VALUE, pkey: *const VALUE, pretval: *mut VALUE) -> VALUE_RESULT,
+	pub ValueToString: extern "system" fn(pval: *mut VALUE, how: VALUE_STRING_CVT_TYPE) -> VALUE_RESULT,
+	pub ValueFromString: extern "system" fn(pval: *mut VALUE, str: LPCWSTR, strLength: UINT, how: VALUE_STRING_CVT_TYPE) -> UINT,
+	pub ValueInvoke: extern "system" fn(
+		pval: *const VALUE,
+		pthis: *mut VALUE,
+		argc: UINT,
+		argv: *const VALUE,
+		pretval: *mut VALUE,
+		url: LPCWSTR,
+	) -> VALUE_RESULT,
+	pub ValueNativeFunctorSet:
+		extern "system" fn(pval: *mut VALUE, pinvoke: NATIVE_FUNCTOR_INVOKE, prelease: NATIVE_FUNCTOR_RELEASE, tag: LPVOID) -> VALUE_RESULT,
+	pub ValueIsNativeFunctor: extern "system" fn(pval: *const VALUE) -> BOOL,
 
 	// tiscript VM API
+	#[deprecated(since = "Sciter 4.4.3.24", note = "TIScript native API is gone, use SOM instead.")]
+	pub TIScriptAPI: extern "system" fn() -> *mut tiscript_native_interface,
 
-	#[deprecated(since="Sciter 4.4.3.24", note="TIScript native API is gone, use SOM instead.")]
-	pub TIScriptAPI: extern "system" fn () -> * mut tiscript_native_interface,
-
-	#[deprecated(since="Sciter 4.4.3.24", note="TIScript native API is gone, use SOM instead.")]
-	pub SciterGetVM: extern "system" fn (hwnd: HWINDOW) -> HVM,
+	#[deprecated(since = "Sciter 4.4.3.24", note = "TIScript native API is gone, use SOM instead.")]
+	pub SciterGetVM: extern "system" fn(hwnd: HWINDOW) -> HVM,
 
 	// since 3.1.0.12
-	#[deprecated(since="Sciter 4.4.3.24", note="TIScript native API is gone, use SOM instead.")]
-	pub Sciter_v2V: extern "system" fn (vm: HVM, script_value: tiscript_value, value: * mut VALUE, isolate: BOOL) -> BOOL,
+	#[deprecated(since = "Sciter 4.4.3.24", note = "TIScript native API is gone, use SOM instead.")]
+	pub Sciter_v2V: extern "system" fn(vm: HVM, script_value: tiscript_value, value: *mut VALUE, isolate: BOOL) -> BOOL,
 
-	#[deprecated(since="Sciter 4.4.3.24", note="TIScript native API is gone, use SOM instead.")]
-	pub Sciter_V2v: extern "system" fn (vm: HVM, valuev: * const VALUE, script_value: * mut tiscript_value) -> BOOL,
+	#[deprecated(since = "Sciter 4.4.3.24", note = "TIScript native API is gone, use SOM instead.")]
+	pub Sciter_V2v: extern "system" fn(vm: HVM, valuev: *const VALUE, script_value: *mut tiscript_value) -> BOOL,
 
 	// since 3.1.0.18
-	pub SciterOpenArchive: extern "system" fn (archiveData: LPCBYTE, archiveDataLength: UINT) -> HSARCHIVE,
-	pub SciterGetArchiveItem: extern "system" fn (harc: HSARCHIVE, path: LPCWSTR, pdata: * mut LPCBYTE, pdataLength: * mut UINT) -> BOOL,
-	pub SciterCloseArchive: extern "system" fn (harc: HSARCHIVE) -> BOOL,
+	pub SciterOpenArchive: extern "system" fn(archiveData: LPCBYTE, archiveDataLength: UINT) -> HSARCHIVE,
+	pub SciterGetArchiveItem: extern "system" fn(harc: HSARCHIVE, path: LPCWSTR, pdata: *mut LPCBYTE, pdataLength: *mut UINT) -> BOOL,
+	pub SciterCloseArchive: extern "system" fn(harc: HSARCHIVE) -> BOOL,
 
 	// since 3.2.0.0
-	pub SciterFireEvent: extern "system" fn (evt: * const BEHAVIOR_EVENT_PARAMS, post: BOOL, handled: * mut BOOL) -> SCDOM_RESULT,
+	pub SciterFireEvent: extern "system" fn(evt: *const BEHAVIOR_EVENT_PARAMS, post: BOOL, handled: *mut BOOL) -> SCDOM_RESULT,
 
-	pub SciterGetCallbackParam: extern "system" fn (hwnd: HWINDOW) -> LPVOID,
-	pub SciterPostCallback: extern "system" fn (hwnd: HWINDOW, wparam: UINT_PTR, lparam: UINT_PTR, timeoutms: UINT) -> UINT_PTR,
+	pub SciterGetCallbackParam: extern "system" fn(hwnd: HWINDOW) -> LPVOID,
+	pub SciterPostCallback: extern "system" fn(hwnd: HWINDOW, wparam: UINT_PTR, lparam: UINT_PTR, timeoutms: UINT) -> UINT_PTR,
 
 	// since 3.3.1.0
-	pub GetSciterGraphicsAPI: extern "system" fn () -> * const SciterGraphicsAPI,
+	pub GetSciterGraphicsAPI: extern "system" fn() -> *const SciterGraphicsAPI,
 
 	// since 3.3.1.6
-	pub GetSciterRequestAPI: extern "system" fn () -> * const SciterRequestAPI,
+	pub GetSciterRequestAPI: extern "system" fn() -> *const SciterRequestAPI,
 
-  // #ifdef WINDOWS
-  // since 3.3.1.4
-  #[cfg_attr(not(all(windows, not(feature = "windowless"))), deprecated(note = "Windows only"))]
-	pub SciterCreateOnDirectXWindow: extern "system" fn (hwnd: HWINDOW, pSwapChain: * mut IDXGISwapChain) -> BOOL,
+	// #ifdef WINDOWS
+	// since 3.3.1.4
 	#[cfg_attr(not(all(windows, not(feature = "windowless"))), deprecated(note = "Windows only"))]
-	pub SciterRenderOnDirectXWindow: extern "system" fn (hwnd: HWINDOW, elementToRenderOrNull: HELEMENT, frontLayer: BOOL) -> BOOL,
+	pub SciterCreateOnDirectXWindow: extern "system" fn(hwnd: HWINDOW, pSwapChain: *mut IDXGISwapChain) -> BOOL,
 	#[cfg_attr(not(all(windows, not(feature = "windowless"))), deprecated(note = "Windows only"))]
-	pub SciterRenderOnDirectXTexture: extern "system" fn (hwnd: HWINDOW, elementToRenderOrNull: HELEMENT, surface: * mut IDXGISurface) -> BOOL,
-  // #endif
+	pub SciterRenderOnDirectXWindow: extern "system" fn(hwnd: HWINDOW, elementToRenderOrNull: HELEMENT, frontLayer: BOOL) -> BOOL,
+	#[cfg_attr(not(all(windows, not(feature = "windowless"))), deprecated(note = "Windows only"))]
+	pub SciterRenderOnDirectXTexture: extern "system" fn(hwnd: HWINDOW, elementToRenderOrNull: HELEMENT, surface: *mut IDXGISurface) -> BOOL,
+	// #endif
 
-  // since 4.0.0.0
-	pub SciterProcX: extern "system" fn(hwnd: HWINDOW, msg: * const SCITER_X_MSG) -> BOOL,
+	// since 4.0.0.0
+	pub SciterProcX: extern "system" fn(hwnd: HWINDOW, msg: *const SCITER_X_MSG) -> BOOL,
 
 	// since 4.4.2.14
 	pub SciterAtomValue: extern "system" fn(name: LPCSTR) -> som_atom_t,
@@ -292,5 +324,4 @@ pub struct ISciterAPI
 	pub SciterElementWrap: extern "system" fn(pval: *mut VALUE, pElement: HELEMENT) -> SCDOM_RESULT,
 	pub SciterNodeUnwrap: extern "system" fn(pval: *const VALUE, ppElement: *mut HNODE) -> SCDOM_RESULT,
 	pub SciterNodeWrap: extern "system" fn(pval: *mut VALUE, pElement: HNODE) -> SCDOM_RESULT,
-
 }

--- a/src/capi/scapi.rs
+++ b/src/capi/scapi.rs
@@ -21,7 +21,7 @@ pub struct ISciterAPI {
 	pub version: UINT,
 
 	pub SciterClassName: extern "system" fn() -> LPCWSTR,
-	pub SciterVersion: extern "system" fn(major: BOOL) -> UINT,
+	pub SciterVersion: extern "system" fn(n: UINT) -> UINT,
 
 	pub SciterDataReady: extern "system" fn(hwnd: HWINDOW, uri: LPCWSTR, data: LPCBYTE, dataLength: UINT) -> BOOL,
 	pub SciterDataReadyAsync: extern "system" fn(hwnd: HWINDOW, uri: LPCWSTR, data: LPCBYTE, dataLength: UINT, requestId: HREQUEST) -> BOOL,

--- a/src/capi/scbehavior.rs
+++ b/src/capi/scbehavior.rs
@@ -3,15 +3,18 @@
 #![allow(non_camel_case_types, non_snake_case)]
 #![allow(dead_code)]
 
-use capi::sctypes::*;
-use capi::scdom::*;
-use capi::scvalue::{VALUE};
-use capi::scgraphics::{HGFX};
-use capi::scom::{som_asset_t, som_passport_t};
+use bitflags::bitflags;
+
+use crate::capi::{
+	scdom::*,
+	scgraphics::HGFX,
+	scom::{som_asset_t, som_passport_t},
+	sctypes::*,
+	scvalue::VALUE,
+};
 
 #[repr(C)]
-pub struct BEHAVIOR_EVENT_PARAMS
-{
+pub struct BEHAVIOR_EVENT_PARAMS {
 	/// Behavior event code. See [`BEHAVIOR_EVENTS`](enum.BEHAVIOR_EVENTS.html).
 	pub cmd: UINT,
 
@@ -32,41 +35,33 @@ pub struct BEHAVIOR_EVENT_PARAMS
 	pub name: LPCWSTR,
 }
 
-
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[derive(Debug, PartialOrd, PartialEq)]
-pub enum INITIALIZATION_EVENTS
-{
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
+pub enum INITIALIZATION_EVENTS {
 	BEHAVIOR_DETACH = 0,
 	BEHAVIOR_ATTACH = 1,
 }
 
 #[repr(C)]
-pub struct INITIALIZATION_PARAMS
-{
+pub struct INITIALIZATION_PARAMS {
 	pub cmd: INITIALIZATION_EVENTS,
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[derive(Debug, PartialOrd, PartialEq)]
-pub enum SOM_EVENTS
-{
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
+pub enum SOM_EVENTS {
 	SOM_GET_PASSPORT = 0,
 	SOM_GET_ASSET = 1,
 }
 
 #[repr(C)]
-pub union SOM_PARAMS_DATA
-{
+pub union SOM_PARAMS_DATA {
 	pub asset: *const som_asset_t,
 	pub passport: *const som_passport_t,
 }
 
 #[repr(C)]
-pub struct SOM_PARAMS
-{
+pub struct SOM_PARAMS {
 	pub cmd: SOM_EVENTS,
 	pub result: SOM_PARAMS_DATA,
 }
@@ -75,48 +70,47 @@ pub struct SOM_PARAMS
 #[repr(C)]
 #[derive(Debug)]
 pub enum BEHAVIOR_METHOD_IDENTIFIERS {
-  /// Raise a click event.
-  DO_CLICK = 1,
+	/// Raise a click event.
+	DO_CLICK = 1,
 
-  /// `IS_EMPTY_PARAMS::is_empty` reflects the `:empty` state of the element.
-  IS_EMPTY = 0xFC,
+	/// `IS_EMPTY_PARAMS::is_empty` reflects the `:empty` state of the element.
+	IS_EMPTY = 0xFC,
 
-  /// `VALUE_PARAMS`
-  GET_VALUE = 0xFD,
-  /// `VALUE_PARAMS`
-  SET_VALUE = 0xFE,
+	/// `VALUE_PARAMS`
+	GET_VALUE = 0xFD,
+	/// `VALUE_PARAMS`
+	SET_VALUE = 0xFE,
 
-  /// User method identifier used in custom behaviors.
-  ///
-  /// All custom event codes shall be greater than this number.
-  /// All codes below this will be used solely by application - Sciter will not intrepret it
-  /// and will do just dispatching. To send event notifications with  these codes use
-  /// `SciterCallBehaviorMethod` API.
-  FIRST_APPLICATION_METHOD_ID = 0x100,
+	/// User method identifier used in custom behaviors.
+	///
+	/// All custom event codes shall be greater than this number.
+	/// All codes below this will be used solely by application - Sciter will not intrepret it
+	/// and will do just dispatching. To send event notifications with  these codes use
+	/// `SciterCallBehaviorMethod` API.
+	FIRST_APPLICATION_METHOD_ID = 0x100,
 }
 
 /// Method arguments used in `SciterCallBehaviorMethod()` or `HANDLE_METHOD_CALL`.
 #[repr(C)]
 pub struct METHOD_PARAMS {
-  /// [`BEHAVIOR_METHOD_IDENTIFIERS`](enum.BEHAVIOR_METHOD_IDENTIFIERS.html) or user identifiers.
-  pub method: UINT,
+	/// [`BEHAVIOR_METHOD_IDENTIFIERS`](enum.BEHAVIOR_METHOD_IDENTIFIERS.html) or user identifiers.
+	pub method: UINT,
 }
 
 #[repr(C)]
 pub struct IS_EMPTY_PARAMS {
-  pub method: UINT,
-  pub is_empty: UINT,
+	pub method: UINT,
+	pub is_empty: UINT,
 }
 
 #[repr(C)]
 pub struct VALUE_PARAMS {
-  pub method: UINT,
-  pub value: VALUE,
+	pub method: UINT,
+	pub value: VALUE,
 }
 
 #[repr(C)]
-pub struct SCRIPTING_METHOD_PARAMS
-{
+pub struct SCRIPTING_METHOD_PARAMS {
 	pub name: LPCSTR,
 	pub argv: *const VALUE,
 	pub argc: UINT,
@@ -124,8 +118,7 @@ pub struct SCRIPTING_METHOD_PARAMS
 }
 
 #[repr(C)]
-pub struct TIMER_PARAMS
-{
+pub struct TIMER_PARAMS {
 	pub timerId: UINT_PTR,
 }
 
@@ -146,8 +139,7 @@ pub struct DRAW_PARAMS {
 
 /// Layer to draw.
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum DRAW_EVENTS {
 	DRAW_BACKGROUND = 0,
 	DRAW_CONTENT,
@@ -156,80 +148,77 @@ pub enum DRAW_EVENTS {
 	DRAW_OUTLINE,
 }
 
-
 /// Event groups for subscription.
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[derive(Debug, PartialOrd, PartialEq)]
-pub enum EVENT_GROUPS
-{ /// Attached/detached.
-	HANDLE_INITIALIZATION = 0x0000,
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
+pub struct EVENT_GROUPS(i32);
+
+bitflags! {
+impl EVENT_GROUPS: i32 {
+	/// Attached/detached.
+	const HANDLE_INITIALIZATION = 0x0000;
 	/// Mouse events.
-	HANDLE_MOUSE = 0x0001,
+	const HANDLE_MOUSE = 0x0001;
 	/// Key events.
-	HANDLE_KEY = 0x0002,
+	const HANDLE_KEY = 0x0002;
 	/// Focus events, if this flag is set it also means that element it attached to is focusable.
-	HANDLE_FOCUS = 0x0004,
+	const HANDLE_FOCUS = 0x0004;
 	/// Scroll events.
-	HANDLE_SCROLL = 0x0008,
+	const HANDLE_SCROLL = 0x0008;
 	/// Timer event.
-	HANDLE_TIMER = 0x0010,
+	const HANDLE_TIMER = 0x0010;
 	/// Size changed event.
-	HANDLE_SIZE = 0x0020,
+	const HANDLE_SIZE = 0x0020;
 	/// Drawing request (event).
-	HANDLE_DRAW = 0x0040,
+	const HANDLE_DRAW = 0x0040;
 	/// Requested data has been delivered.
-	HANDLE_DATA_ARRIVED = 0x080,
+	const HANDLE_DATA_ARRIVED = 0x080;
 
 	/// Logical, synthetic events:
-  /// `BUTTON_CLICK`, `HYPERLINK_CLICK`, etc.,
+	/// `BUTTON_CLICK`, `HYPERLINK_CLICK`, etc.,
 	/// a.k.a. notifications from intrinsic behaviors.
-	HANDLE_BEHAVIOR_EVENT        = 0x0100,
-	 /// Behavior specific methods.
-	HANDLE_METHOD_CALL           = 0x0200,
+	const HANDLE_BEHAVIOR_EVENT = 0x0100;
 	/// Behavior specific methods.
-	HANDLE_SCRIPTING_METHOD_CALL = 0x0400,
+	const HANDLE_METHOD_CALL = 0x0200;
+	/// Behavior specific methods.
+	const HANDLE_SCRIPTING_METHOD_CALL = 0x0400;
 
 	/// Behavior specific methods using direct `tiscript::value`'s.
-	#[deprecated(since="Sciter 4.4.3.24", note="TIScript native API is gone, use SOM instead.")]
-	HANDLE_TISCRIPT_METHOD_CALL  = 0x0800,
+	#[deprecated(since = "Sciter 4.4.3.24", note = "TIScript native API is gone, use SOM instead.")]
+	const HANDLE_TISCRIPT_METHOD_CALL = 0x0800;
 
 	/// System drag-n-drop.
-	HANDLE_EXCHANGE              = 0x1000,
+	const HANDLE_EXCHANGE = 0x1000;
 	/// Touch input events.
-	HANDLE_GESTURE               = 0x2000,
+	const HANDLE_GESTURE = 0x2000;
 	/// SOM passport and asset requests.
-	HANDLE_SOM                   = 0x8000,
+	const HANDLE_SOM = 0x8000;
 
 	/// All of them.
-	HANDLE_ALL                   = 0xFFFF,
+	const HANDLE_ALL = 0xFFFF;
 
 	/// Special value for getting subscription flags.
-	SUBSCRIPTIONS_REQUEST        = -1,
-}
+	const SUBSCRIPTIONS_REQUEST = -1;
+}}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[derive(Debug, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
 /// Event propagation schema.
-pub enum PHASE_MASK
-{
+pub enum PHASE_MASK {
 	/// Bubbling phase – direction: from a child element to all its containers.
-	BUBBLING 				= 0,
+	BUBBLING = 0,
 	/// Sinking phase – direction: from containers to target child element.
-	SINKING  				= 0x0_8000,
+	SINKING = 0x0_8000,
 	/// Bubbling event consumed by some element.
-	BUBBLING_HANDLED= 0x1_0000,
+	BUBBLING_HANDLED = 0x1_0000,
 	/// Sinking event consumed by some child.
 	SINKING_HANDLED = 0x1_8000,
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[derive(Debug, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
 /// Mouse buttons.
-pub enum MOUSE_BUTTONS
-{
+pub enum MOUSE_BUTTONS {
 	NONE = 0,
 
 	/// Left button.
@@ -241,8 +230,7 @@ pub enum MOUSE_BUTTONS
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[derive(Debug, Default, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, PartialOrd, PartialEq)]
 /// Keyboard modifier buttons state.
 pub struct KEYBOARD_STATES(u32);
 
@@ -261,22 +249,18 @@ impl std::convert::From<u32> for KEYBOARD_STATES {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[derive(Debug, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
 /// Keyboard input events.
-pub enum KEY_EVENTS
-{
+pub enum KEY_EVENTS {
 	KEY_DOWN = 0,
 	KEY_UP,
 	KEY_CHAR,
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[derive(Debug, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
 /// Mouse events.
-pub enum MOUSE_EVENTS
-{
+pub enum MOUSE_EVENTS {
 	MOUSE_ENTER = 0,
 	MOUSE_LEAVE,
 	MOUSE_MOVE,
@@ -290,11 +274,11 @@ pub enum MOUSE_EVENTS
 	MOUSE_IDLE,
 
 	/// item dropped, target is that dropped item
-	DROP        = 9,
+	DROP = 9,
 	/// drag arrived to the target element that is one of current drop targets.
-	DRAG_ENTER  = 0xA,
+	DRAG_ENTER = 0xA,
 	/// drag left one of current drop targets. target is the drop target element.
-	DRAG_LEAVE  = 0xB,
+	DRAG_LEAVE = 0xB,
 	/// drag src notification before drag start. To cancel - return true from handler.
 	DRAG_REQUEST = 0xC,
 
@@ -310,28 +294,24 @@ pub enum MOUSE_EVENTS
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[derive(Debug, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
 #[allow(missing_docs)]
 /// General event source triggers
-pub enum CLICK_REASON
-{
-  /// By mouse button.
+pub enum CLICK_REASON {
+	/// By mouse button.
 	BY_MOUSE_CLICK,
-  /// By keyboard (e.g. spacebar).
+	/// By keyboard (e.g. spacebar).
 	BY_KEY_CLICK,
-  /// Synthesized, by code.
+	/// Synthesized, by code.
 	SYNTHESIZED,
-  /// Icon click, e.g. arrow icon on drop-down select.
+	/// Icon click, e.g. arrow icon on drop-down select.
 	BY_MOUSE_ON_ICON,
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[derive(Debug, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
 /// Edit control change trigger.
-pub enum EDIT_CHANGED_REASON
-{
+pub enum EDIT_CHANGED_REASON {
 	/// Single char insertion.
 	BY_INS_CHAR,
 	/// Character range insertion, clipboard.
@@ -350,11 +330,9 @@ pub enum EDIT_CHANGED_REASON
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[derive(Debug, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
 /// Behavior event codes.
-pub enum BEHAVIOR_EVENTS
-{
+pub enum BEHAVIOR_EVENTS {
 	/// click on button
 	BUTTON_CLICK = 0,
 	/// mouse down or key down in button
@@ -395,16 +373,9 @@ pub enum BEHAVIOR_EVENTS
 	///   BEHAVIOR_EVENT_PARAMS.reason - BY_MOUSE_CLICK | BY_KEY_CLICK
 	MENU_ITEM_CLICK,
 
-
-
-
-
-
-
 	/// "right-click", BEHAVIOR_EVENT_PARAMS::he is current popup menu `HELEMENT` being processed or `NULL`.
 	/// application can provide its own `HELEMENT` here (if it is `NULL`) or modify current menu element.
 	CONTEXT_MENU_REQUEST = 0x10,
-
 
 	/// broadcast notification, sent to all elements of some container being shown or hidden
 	VISIUAL_STATUS_CHANGED,
@@ -417,7 +388,6 @@ pub enum BEHAVIOR_EVENTS
 	/// content has been changed, is posted to the element that gets content changed,  reason is combination of `CONTENT_CHANGE_BITS`.
 	/// `target == NULL` means the window got new document and this event is dispatched only to the window.
 	CONTENT_CHANGED = 0x15,
-
 
 	/// generic click
 	CLICK = 0x16,
@@ -456,19 +426,15 @@ pub enum BEHAVIOR_EVENTS
 	/// is sent, for example, by `behavior:richtext` when caret position/selection has changed.
 	UI_STATE_CHANGED = 0x95,
 
-
 	/// `behavior:form` detected submission event. `BEHAVIOR_EVENT_PARAMS::data` field contains data to be posted.
 	/// `BEHAVIOR_EVENT_PARAMS::data` is of type `T_MAP` in this case key/value pairs of data that is about
 	/// to be submitted. You can modify the data or discard submission by returning true from the handler.
 	FORM_SUBMIT,
 
-
 	/// `behavior:form` detected reset event (from `button type=reset`). `BEHAVIOR_EVENT_PARAMS::data` field contains data to be reset.
 	/// `BEHAVIOR_EVENT_PARAMS::data` is of type `T_MAP` in this case key/value pairs of data that is about
 	/// to be rest. You can modify the data or discard reset by returning true from the handler.
 	FORM_RESET,
-
-
 
 	/// document in `behavior:frame` or root document is complete.
 	DOCUMENT_COMPLETE,
@@ -487,10 +453,10 @@ pub enum BEHAVIOR_EVENTS
 	TOOLTIP_REQUEST,
 
 	/// animation started (`reason=1`) or ended(`reason=0`) on the element.
-	ANIMATION         = 0xA0,
+	ANIMATION = 0xA0,
 
 	/// document created, script namespace initialized. `target` -> the document
-	DOCUMENT_CREATED  = 0xC0,
+	DOCUMENT_CREATED = 0xC0,
 	/// document is about to be closed, to cancel closing do: `evt.data = sciter::Value("cancel")`;
 	DOCUMENT_CLOSE_REQUEST,
 	/// last notification before document removal from the DOM
@@ -499,7 +465,7 @@ pub enum BEHAVIOR_EVENTS
 	DOCUMENT_READY,
 	/// document just finished parsing - has got DOM structure. This event is generated before the `DOCUMENT_READY`.
 	/// Since 4.0.3.
-	DOCUMENT_PARSED   = 0xC4,
+	DOCUMENT_PARSED = 0xC4,
 
 	/// `<video>` "ready" notification
 	VIDEO_INITIALIZED = 0xD1,
@@ -519,9 +485,8 @@ pub enum BEHAVIOR_EVENTS
 	///      call `sciter::video_destination::stop_streaming()` to stop the rendering (a.k.a. end of movie reached)
 	VIDEO_BIND_RQ,
 
-
 	/// `behavior:pager` starts pagination
-	PAGINATION_STARTS  = 0xE0,
+	PAGINATION_STARTS = 0xE0,
 	/// `behavior:pager` paginated page no, reason -> page no
 	PAGINATION_PAGE,
 	/// `behavior:pager` end pagination, reason -> total pages
@@ -529,23 +494,22 @@ pub enum BEHAVIOR_EVENTS
 
 	/// event with custom name.
 	/// Since 4.2.8.
-	CUSTOM						 = 0xF0,
+	CUSTOM = 0xF0,
 
 	/// SSX, delayed mount_component
-	MOUNT_COMPONENT    = 0xF1,
+	MOUNT_COMPONENT = 0xF1,
 
 	/// all custom event codes shall be greater than this number. All codes below this will be used
 	/// solely by application - Sciter will not intrepret it and will do just dispatching.
 	/// To send event notifications with  these codes use `SciterSend`/`PostEvent` API.
 	FIRST_APPLICATION_EVENT_CODE = 0x100,
-
 }
 
-
-impl ::std::ops::BitOr for EVENT_GROUPS {
-  type Output = EVENT_GROUPS;
-  fn bitor(self, rhs: Self::Output) -> Self::Output {
-    let rn = (self as UINT) | (rhs as UINT);
-    unsafe { ::std::mem::transmute(rn) }
-  }
+/* impl ::std::ops::BitOr for EVENT_GROUPS {
+	type Output = EVENT_GROUPS;
+	fn bitor(self, rhs: Self::Output) -> Self::Output {
+		let rn = (self as UINT) | (rhs as UINT);
+		unsafe { ::std::mem::transmute(rn) }
+	}
 }
+ */

--- a/src/capi/scdef.rs
+++ b/src/capi/scdef.rs
@@ -3,11 +3,13 @@
 #![allow(non_camel_case_types, non_snake_case)]
 #![allow(dead_code)]
 
-use capi::sctypes::*;
-use capi::scvalue::{VALUE};
-use capi::screquest::{HREQUEST};
-use capi::scdom::{HELEMENT};
-use capi::scapi::ISciterAPI;
+use bitflags::bitflags;
+
+use crate::capi::scapi::ISciterAPI;
+use crate::capi::scdom::HELEMENT;
+use crate::capi::screquest::HREQUEST;
+use crate::capi::sctypes::*;
+use crate::capi::scvalue::VALUE;
 
 //////////////////////////////////////////////////////////////////////////////////
 pub enum ID2D1RenderTarget {}
@@ -15,7 +17,6 @@ pub enum ID2D1Factory {}
 pub enum IDWriteFactory {}
 pub enum IDXGISwapChain {}
 pub enum IDXGISurface {}
-
 
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
@@ -26,22 +27,21 @@ pub enum IDXGISurface {}
 /// a database or other resource).
 pub enum LOAD_RESULT {
 	/// Do the default loading if data is not set.
-  LOAD_DEFAULT,
-  /// Discard the request completely (data will not be loaded at the document).
-  LOAD_DISCARD,
-  /// Data will be delivered later by the host application.
-  LOAD_DELAYED,
-  /// You return this result to indicate that your (the host) application took or
-  /// will take care about `HREQUEST` in your code completely.
-  LOAD_MYSELF,
+	LOAD_DEFAULT,
+	/// Discard the request completely (data will not be loaded at the document).
+	LOAD_DISCARD,
+	/// Data will be delivered later by the host application.
+	LOAD_DELAYED,
+	/// You return this result to indicate that your (the host) application took or
+	/// will take care about `HREQUEST` in your code completely.
+	LOAD_MYSELF,
 }
 
 /// Script runtime options.
 #[repr(C)]
 #[derive(Debug)]
 #[allow(missing_docs)]
-pub enum SCRIPT_RUNTIME_FEATURES
-{
+pub enum SCRIPT_RUNTIME_FEATURES {
 	ALLOW_FILE_IO = 0x1,
 	ALLOW_SOCKET_IO = 0x2,
 	ALLOW_EVAL = 0x4,
@@ -50,11 +50,9 @@ pub enum SCRIPT_RUNTIME_FEATURES
 
 /// Sciter graphics rendering backend.
 #[repr(C)]
-#[derive(Debug)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 #[allow(missing_docs)]
-pub enum GFX_LAYER
-{
+pub enum GFX_LAYER {
 	/// An auto-selected backend.
 	AUTO = 0xFFFF,
 
@@ -79,37 +77,36 @@ pub enum GFX_LAYER
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
 /// Various Sciter engine options (global or per-window).
-pub enum SCITER_RT_OPTIONS
-{
+pub enum SCITER_RT_OPTIONS {
 	/// value:TRUE - enable, value:FALSE - disable, enabled by default.
-  SCITER_SMOOTH_SCROLL = 1,
-  /// global; value: milliseconds, connection timeout of http client.
-  SCITER_CONNECTION_TIMEOUT = 2,
-  /// global; value: 0 - drop connection, 1 - use builtin dialog, 2 - accept connection silently.
-  SCITER_HTTPS_ERROR = 3,
-  /// value: 0 - system default, 1 - no smoothing, 2 - std smoothing, 3 - clear type.
-  SCITER_FONT_SMOOTHING = 4,
+	SCITER_SMOOTH_SCROLL = 1,
+	/// global; value: milliseconds, connection timeout of http client.
+	SCITER_CONNECTION_TIMEOUT = 2,
+	/// global; value: 0 - drop connection, 1 - use builtin dialog, 2 - accept connection silently.
+	SCITER_HTTPS_ERROR = 3,
+	/// value: 0 - system default, 1 - no smoothing, 2 - std smoothing, 3 - clear type.
+	SCITER_FONT_SMOOTHING = 4,
 	/// Windows Aero support, value:
 	/// 0 - normal drawing,
 	/// 1 - window has transparent background after calls `DwmExtendFrameIntoClientArea()` or `DwmEnableBlurBehindWindow()`.
-  SCITER_TRANSPARENT_WINDOW = 6,
-  /// global; value = LPCBYTE, json - GPU black list, see: gpu-blacklist.json resource.
-  /// Note: is not used since Sciter 4.
-  #[deprecated(since="4.0.1", note="This option isn't working since Sciter 4.0.1.1.")]
-  SCITER_SET_GPU_BLACKLIST  = 7,
-  /// global or per-window; value - combination of [SCRIPT_RUNTIME_FEATURES](enum.SCRIPT_RUNTIME_FEATURES.html) flags.
-  SCITER_SET_SCRIPT_RUNTIME_FEATURES = 8,
-  /// global (must be called before any window creation); value - [GFX_LAYER](enum.GFX_LAYER.html).
-  SCITER_SET_GFX_LAYER = 9,
-  /// global or per-window; value - TRUE/FALSE
-  SCITER_SET_DEBUG_MODE = 10,
-  /// global; value - BOOL, TRUE - the engine will use "unisex" theme that is common for all platforms.
-  /// That UX theme is not using OS primitives for rendering input elements.
-  /// Use it if you want exactly the same (modulo fonts) look-n-feel on all platforms.
-  SCITER_SET_UX_THEMING = 11,
-  /// value - TRUE/FALSE - window uses per pixel alpha (e.g. `WS_EX_LAYERED`/`UpdateLayeredWindow()` window).
-  SCITER_ALPHA_WINDOW  = 12,
-  /// global; value: UTF-8 encoded script source to be loaded into each view before any other script execution.
+	SCITER_TRANSPARENT_WINDOW = 6,
+	/// global; value = LPCBYTE, json - GPU black list, see: gpu-blacklist.json resource.
+	/// Note: is not used since Sciter 4.
+	#[deprecated(since = "4.0.1", note = "This option isn't working since Sciter 4.0.1.1.")]
+	SCITER_SET_GPU_BLACKLIST = 7,
+	/// global or per-window; value - combination of [SCRIPT_RUNTIME_FEATURES](enum.SCRIPT_RUNTIME_FEATURES.html) flags.
+	SCITER_SET_SCRIPT_RUNTIME_FEATURES = 8,
+	/// global (must be called before any window creation); value - [GFX_LAYER](enum.GFX_LAYER.html).
+	SCITER_SET_GFX_LAYER = 9,
+	/// global or per-window; value - TRUE/FALSE
+	SCITER_SET_DEBUG_MODE = 10,
+	/// global; value - BOOL, TRUE - the engine will use "unisex" theme that is common for all platforms.
+	/// That UX theme is not using OS primitives for rendering input elements.
+	/// Use it if you want exactly the same (modulo fonts) look-n-feel on all platforms.
+	SCITER_SET_UX_THEMING = 11,
+	/// value - TRUE/FALSE - window uses per pixel alpha (e.g. `WS_EX_LAYERED`/`UpdateLayeredWindow()` window).
+	SCITER_ALPHA_WINDOW = 12,
+	/// global; value: UTF-8 encoded script source to be loaded into each view before any other script execution.
 	SCITER_SET_INIT_SCRIPT = 13,
 	/// per-window; value - TRUE/FALSE - window is main, will destroy all other dependent windows on close.
 	SCITER_SET_MAIN_WINDOW = 14,
@@ -119,31 +116,33 @@ pub enum SCITER_RT_OPTIONS
 	SCITER_SET_PX_AS_DIP = 16,
 }
 
-/// Window flags
-#[repr(C)]
-pub enum SCITER_CREATE_WINDOW_FLAGS {
+// Window flags
+//#[repr(C)]
+bitflags! {
+pub struct SCITER_CREATE_WINDOW_FLAGS: u32 {
 	/// child window only, if this flag is set all other flags ignored.
-  SW_CHILD      = 1,
-  /// toplevel window, has titlebar.
-  SW_TITLEBAR   = 1 << 1,
-  /// has resizeable frame.
-  SW_RESIZEABLE = 1 << 2,
-  /// is tool window.
-  SW_TOOL       = 1 << 3,
-  /// has minimize / maximize buttons.
-  SW_CONTROLS   = 1 << 4,
-  /// glassy window - "Acrylic" on Windows and "Vibrant" on macOS.
-  SW_GLASSY     = 1 << 5,
-  /// transparent window (e.g. `WS_EX_LAYERED` on Windows, macOS is supported too).
-  SW_ALPHA      = 1 << 6,
-  /// main window of the app, will terminate the app on close.
-  SW_MAIN       = 1 << 7,
-  /// the window is created as topmost window.
-  SW_POPUP      = 1 << 8,
-  /// make this window inspector ready.
-  SW_ENABLE_DEBUG = 1 << 9,
-  /// it has its own script VM.
-  SW_OWNS_VM      = 1 << 10,
+	const SW_CHILD      = 1;
+	/// toplevel window, has titlebar.
+	const SW_TITLEBAR   = 1 << 1;
+	/// has resizeable frame.
+	const SW_RESIZEABLE = 1 << 2;
+	/// is tool window.
+	const SW_TOOL       = 1 << 3;
+	/// has minimize / maximize buttons.
+	const SW_CONTROLS   = 1 << 4;
+	/// glassy window - "Acrylic" on Windows and "Vibrant" on macOS.
+	const SW_GLASSY     = 1 << 5;
+	/// transparent window (e.g. `WS_EX_LAYERED` on Windows, macOS is supported too).
+	const SW_ALPHA      = 1 << 6;
+	/// main window of the app, will terminate the app on close.
+	const SW_MAIN       = 1 << 7;
+	/// the window is created as topmost window.
+	const SW_POPUP      = 1 << 8;
+	/// make this window inspector ready.
+	const SW_ENABLE_DEBUG = 1 << 9;
+	/// it has its own script VM.
+	const SW_OWNS_VM      = 1 << 10;
+}
 }
 
 impl Default for SCITER_CREATE_WINDOW_FLAGS {
@@ -152,23 +151,23 @@ impl Default for SCITER_CREATE_WINDOW_FLAGS {
 	}
 }
 
-/// Flags can be OR'ed as `SW_MAIN|SW_ALPHA`.
+/* /// Flags can be OR'ed as `SW_MAIN|SW_ALPHA`.
 impl ::std::ops::BitOr for SCITER_CREATE_WINDOW_FLAGS {
-  type Output = SCITER_CREATE_WINDOW_FLAGS;
-  fn bitor(self, rhs: Self::Output) -> Self::Output {
-    let rn = (self as UINT) | (rhs as UINT);
-    unsafe { ::std::mem::transmute(rn) }
-  }
+	type Output = SCITER_CREATE_WINDOW_FLAGS;
+	fn bitor(self, rhs: Self::Output) -> Self::Output {
+		let rn = (self as UINT) | (rhs as UINT);
+		unsafe { ::std::mem::transmute(rn) }
+	}
 }
-
+ */
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
 pub enum SCITER_NOTIFICATION {
-  SC_LOAD_DATA = 1,
-  SC_DATA_LOADED = 2,
-  SC_ATTACH_BEHAVIOR = 4,
-  SC_ENGINE_DESTROYED = 5,
-  SC_POSTED_NOTIFICATION = 6,
+	SC_LOAD_DATA = 1,
+	SC_DATA_LOADED = 2,
+	SC_ATTACH_BEHAVIOR = 4,
+	SC_ENGINE_DESTROYED = 5,
+	SC_POSTED_NOTIFICATION = 6,
 	SC_GRAPHICS_CRITICAL_FAILURE = 7,
 	SC_KEYBOARD_REQUEST = 8,
 	SC_INVALIDATE_RECT = 9,
@@ -199,90 +198,85 @@ pub enum RESOURCE_TYPE {
 /// The type of a loaded resource.
 pub type SCITER_RESOURCE_TYPE = RESOURCE_TYPE;
 
-
 #[repr(C)]
 #[derive(Debug)]
 /// Notifies that Sciter is about to download a referred resource.
-pub struct SCN_LOAD_DATA
-{
+pub struct SCN_LOAD_DATA {
 	/// `SC_LOAD_DATA` here.
-  pub code: UINT,
-  /// `HWINDOW` of the window this callback was attached to.
-  pub hwnd: HWINDOW,
+	pub code: UINT,
+	/// `HWINDOW` of the window this callback was attached to.
+	pub hwnd: HWINDOW,
 
-  /// [in] Zero terminated string, fully qualified uri, for example, "http://server/folder/file.ext".
-  pub uri: LPCWSTR,
+	/// [in] Zero terminated string, fully qualified uri, for example, "http://server/folder/file.ext".
+	pub uri: LPCWSTR,
 
-  /// [in,out] pointer to loaded data to return. If data exists in the cache then this field contain pointer to it.
-  pub outData: LPCBYTE,
-  /// [in,out] loaded data size to return.
-  pub outDataSize: UINT,
+	/// [in,out] pointer to loaded data to return. If data exists in the cache then this field contain pointer to it.
+	pub outData: LPCBYTE,
+	/// [in,out] loaded data size to return.
+	pub outDataSize: UINT,
 
-  /// [in] resource type category
-  pub dataType: RESOURCE_TYPE,
+	/// [in] resource type category
+	pub dataType: RESOURCE_TYPE,
 
-  /// [in] request handle that can be used with Sciter request API.
-  pub request_id: HREQUEST,
+	/// [in] request handle that can be used with Sciter request API.
+	pub request_id: HREQUEST,
 
-  /// [in] destination element for request.
-  pub principal: HELEMENT,
-  /// [in] source element for request.
-  pub initiator: HELEMENT,
+	/// [in] destination element for request.
+	pub principal: HELEMENT,
+	/// [in] source element for request.
+	pub initiator: HELEMENT,
 }
 
 #[repr(C)]
 #[derive(Debug)]
 /// This notification indicates that external data (for example, image) download process has been completed.
-pub struct SCN_DATA_LOADED
-{
+pub struct SCN_DATA_LOADED {
 	/// `SC_DATA_LOADED` here.
-  pub code: UINT,
-  /// `HWINDOW` of the window this callback was attached to.
-  pub hwnd: HWINDOW,
-  /// [in] zero terminated string, fully qualified uri, for example, "http://server/folder/file.ext".
-  pub uri: LPCWSTR,
-  /// [in] pointer to loaded data.
-  pub data: LPCBYTE,
-  /// [in] loaded data size (in bytes).
-  pub dataSize: UINT,
-  /// [in] resource type category
-  pub dataType: RESOURCE_TYPE,
-  /// Download status code:
-  ///
-  /// * status = 0 and `dataSize == 0` - unknown error.
-  /// * status = 100..505 - http response status, note: 200 - OK!
-  /// * status > 12000 - wininet error code, see `ERROR_INTERNET_***` in wininet.h
-  pub status: UINT,
+	pub code: UINT,
+	/// `HWINDOW` of the window this callback was attached to.
+	pub hwnd: HWINDOW,
+	/// [in] zero terminated string, fully qualified uri, for example, "http://server/folder/file.ext".
+	pub uri: LPCWSTR,
+	/// [in] pointer to loaded data.
+	pub data: LPCBYTE,
+	/// [in] loaded data size (in bytes).
+	pub dataSize: UINT,
+	/// [in] resource type category
+	pub dataType: RESOURCE_TYPE,
+	/// Download status code:
+	///
+	/// * status = 0 and `dataSize == 0` - unknown error.
+	/// * status = 100..505 - http response status, note: 200 - OK!
+	/// * status > 12000 - wininet error code, see `ERROR_INTERNET_***` in wininet.h
+	pub status: UINT,
 }
 
 #[repr(C)]
 /// This notification is sent on parsing the document and while processing elements
 /// having non empty `behavior: ` style attribute value.
-pub struct SCN_ATTACH_BEHAVIOR
-{
+pub struct SCN_ATTACH_BEHAVIOR {
 	/// `SC_ATTACH_BEHAVIOR` here.
-  pub code: UINT,
-  /// `HWINDOW` of the window this callback was attached to.
-  pub hwnd: HWINDOW,
+	pub code: UINT,
+	/// `HWINDOW` of the window this callback was attached to.
+	pub hwnd: HWINDOW,
 
-  /// [in] target DOM element handle
-  pub element: HELEMENT,
-  /// [in] zero terminated string, string appears as value of CSS `behavior: ` attribute.
-  pub name: LPCSTR,
-  /// [out] pointer to ElementEventProc function.
-  pub elementProc: ElementEventProc,
-  /// [out] tag value, passed as is into pointer ElementEventProc function.
-  pub elementTag: LPVOID,
+	/// [in] target DOM element handle
+	pub element: HELEMENT,
+	/// [in] zero terminated string, string appears as value of CSS `behavior: ` attribute.
+	pub name: LPCSTR,
+	/// [out] pointer to ElementEventProc function.
+	pub elementProc: ElementEventProc,
+	/// [out] tag value, passed as is into pointer ElementEventProc function.
+	pub elementTag: LPVOID,
 }
 
 #[repr(C)]
 /// This notification is issued when keyboard needs to be shown –
 /// mobiles can show soft keyboard by handling it.
-pub struct SCN_KEYBOARD_REQUEST
-{
+pub struct SCN_KEYBOARD_REQUEST {
 	/// `SC_KEYBOARD_REQUEST` here.
-  pub code: UINT,
-  /// `HWINDOW` of the window this callback was attached to.
+	pub code: UINT,
+	/// `HWINDOW` of the window this callback was attached to.
 	pub hwnd: HWINDOW,
 
 	pub keyboard_mode: UINT,
@@ -291,66 +285,64 @@ pub struct SCN_KEYBOARD_REQUEST
 #[repr(C)]
 /// This notification is sent when a specific window area
 /// needs to be redrawn.
-pub struct SCN_INVALIDATE_RECT
-{
+pub struct SCN_INVALIDATE_RECT {
 	/// `SC_INVALIDATE_RECT` here.
-  pub code: UINT,
-  /// `HWINDOW` of the window this callback was attached to.
-  pub hwnd: HWINDOW,
+	pub code: UINT,
+	/// `HWINDOW` of the window this callback was attached to.
+	pub hwnd: HWINDOW,
 
 	/// Coordinates of the invalidated area.
 	pub invalid_rect: RECT,
 }
 
 #[repr(C)]
-pub struct SCITER_CALLBACK_NOTIFICATION
-{
+pub struct SCITER_CALLBACK_NOTIFICATION {
 	pub code: UINT,
 	pub hwnd: HWINDOW,
 }
 pub type LPSCITER_CALLBACK_NOTIFICATION = *mut SCITER_CALLBACK_NOTIFICATION;
 
-pub type SciterHostCallback = extern "system" fn (pns: LPSCITER_CALLBACK_NOTIFICATION, callbackParam: LPVOID) -> UINT;
+pub type SciterHostCallback = extern "system" fn(pns: LPSCITER_CALLBACK_NOTIFICATION, callbackParam: LPVOID) -> UINT;
 
-pub type SciterWindowDelegate = extern "system" fn (hwnd: HWINDOW, msg: UINT, wParam: WPARAM, lParam: LPARAM, pParam: LPVOID, handled: * mut BOOL) -> LRESULT;
+pub type SciterWindowDelegate =
+	extern "system" fn(hwnd: HWINDOW, msg: UINT, wParam: WPARAM, lParam: LPARAM, pParam: LPVOID, handled: *mut BOOL) -> LRESULT;
 
-pub type ElementEventProc = extern "system" fn (tag: LPVOID, he: HELEMENT, evtg: UINT, prms: LPVOID) -> BOOL;
+pub type ElementEventProc = extern "system" fn(tag: LPVOID, he: HELEMENT, evtg: UINT, prms: LPVOID) -> BOOL;
 
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
 /// Debug output categories.
-pub enum OUTPUT_SUBSYTEMS
-{
+pub enum OUTPUT_SUBSYTEMS {
 	/// html parser & runtime
-  DOM = 0,
-  /// csss! parser & runtime
-  CSSS,
-  /// css parser
-  CSS,
-  /// TIS parser & runtime
-  TIS,
+	DOM = 0,
+	/// csss! parser & runtime
+	CSSS,
+	/// css parser
+	CSS,
+	/// TIS parser & runtime
+	TIS,
 }
 
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
 #[allow(missing_docs)]
 /// Debug output severity.
-pub enum OUTPUT_SEVERITY
-{
-  INFO,
-  WARNING,
-  ERROR,
+pub enum OUTPUT_SEVERITY {
+	INFO,
+	WARNING,
+	ERROR,
 }
 
-pub type DEBUG_OUTPUT_PROC = extern "system" fn (param: LPVOID, subsystem: OUTPUT_SUBSYTEMS, severity: OUTPUT_SEVERITY, text: LPCWSTR, text_length: UINT);
+pub type DEBUG_OUTPUT_PROC =
+	extern "system" fn(param: LPVOID, subsystem: OUTPUT_SUBSYTEMS, severity: OUTPUT_SEVERITY, text: LPCWSTR, text_length: UINT);
 
-pub type LPCWSTR_RECEIVER = extern "system" fn (szstr: LPCWSTR, str_length: UINT, param: LPVOID);
-pub type LPCSTR_RECEIVER  = extern "system" fn (szstr: LPCSTR,  str_length: UINT, param: LPVOID);
-pub type LPCBYTE_RECEIVER = extern "system" fn (szstr: LPCBYTE, str_length: UINT, param: LPVOID);
+pub type LPCWSTR_RECEIVER = extern "system" fn(szstr: LPCWSTR, str_length: UINT, param: LPVOID);
+pub type LPCSTR_RECEIVER = extern "system" fn(szstr: LPCSTR, str_length: UINT, param: LPVOID);
+pub type LPCBYTE_RECEIVER = extern "system" fn(szstr: LPCBYTE, str_length: UINT, param: LPVOID);
 
-pub type ELEMENT_BITMAP_RECEIVER = extern "system" fn (rgba: LPCBYTE, x: INT, y: INT, width: UINT, height: UINT, param: LPVOID);
+pub type ELEMENT_BITMAP_RECEIVER = extern "system" fn(rgba: LPCBYTE, x: INT, y: INT, width: UINT, height: UINT, param: LPVOID);
 
-pub type KeyValueCallback = extern "system" fn (param: LPVOID, pkey: *const VALUE, pval: *const VALUE) -> BOOL;
+pub type KeyValueCallback = extern "system" fn(param: LPVOID, pkey: *const VALUE, pval: *const VALUE) -> BOOL;
 
 /// Signature of Sciter extension library.
 ///
@@ -387,4 +379,4 @@ pub type KeyValueCallback = extern "system" fn (param: LPVOID, pkey: *const VALU
 ///
 /// See the [blog post](https://sciter.com/include-library-name-native-extensions/) for more details.
 ///
-pub type SciterLibraryInit = extern "system" fn (api: &'static ISciterAPI, exported: &mut VALUE) -> BOOL;
+pub type SciterLibraryInit = extern "system" fn(api: &'static ISciterAPI, exported: &mut VALUE) -> BOOL;

--- a/src/capi/scdom.rs
+++ b/src/capi/scdom.rs
@@ -2,10 +2,18 @@
 
 #![allow(non_camel_case_types, non_snake_case)]
 
-use capi::sctypes::*;
+use crate::capi::sctypes::*;
 
-MAKE_HANDLE!(#[doc = "Element native handle."] HELEMENT, _HELEMENT);
-MAKE_HANDLE!(#[doc = "Node native handle."] HNODE, _HNODE);
+MAKE_HANDLE!(
+	#[doc = "Element native handle."]
+	HELEMENT,
+	_HELEMENT
+);
+MAKE_HANDLE!(
+	#[doc = "Node native handle."]
+	HNODE,
+	_HNODE
+);
 
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
@@ -38,21 +46,19 @@ impl std::fmt::Display for SCDOM_RESULT {
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
 /// `dom::Element.set_html()` options.
-pub enum SET_ELEMENT_HTML
-{
-	SIH_REPLACE_CONTENT     = 0,
-	SIH_INSERT_AT_START     = 1,
-	SIH_APPEND_AFTER_LAST   = 2,
-	SOH_REPLACE             = 3,
-	SOH_INSERT_BEFORE       = 4,
-	SOH_INSERT_AFTER        = 5,
+pub enum SET_ELEMENT_HTML {
+	SIH_REPLACE_CONTENT = 0,
+	SIH_INSERT_AT_START = 1,
+	SIH_APPEND_AFTER_LAST = 2,
+	SOH_REPLACE = 3,
+	SOH_INSERT_BEFORE = 4,
+	SOH_INSERT_AFTER = 5,
 }
 
 /// Bounding rectangle of the element.
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
 pub enum ELEMENT_AREAS {
-
 	/// `or` this flag if you want to get Sciter window relative coordinates,
 	/// otherwise it will use nearest windowed container e.g. popup window.
 	ROOT_RELATIVE = 0x01,
@@ -73,10 +79,10 @@ pub enum ELEMENT_AREAS {
 	PADDING_BOX = 0x10,
 
 	/// Content + paddings + border.
-	BORDER_BOX  = 0x20,
+	BORDER_BOX = 0x20,
 
 	/// Content + paddings + border + margins.
-	MARGIN_BOX  = 0x30,
+	MARGIN_BOX = 0x30,
 
 	/// Relative to content origin - location of background image (if it set `no-repeat`).
 	BACK_IMAGE_AREA = 0x40,
@@ -108,126 +114,125 @@ impl ELEMENT_AREAS {
 /// Implements `|` and `&` bitwise operators.
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
-pub enum ELEMENT_STATE_BITS
-{
+pub enum ELEMENT_STATE_BITS {
 	/// Zero state.
-	STATE_NONE             = 0x00000000,
+	STATE_NONE = 0x00000000,
 
 	/// Element is a link.
 	///
 	/// E.g. `<a href`.
-	STATE_LINK             = 0x00000001,
+	STATE_LINK = 0x00000001,
 
 	/// Mouse over the element at the moment.
-	STATE_HOVER            = 0x00000002,
+	STATE_HOVER = 0x00000002,
 	/// Element is pressed.
 	///
 	/// Commonly used by `<button>` or `<a>` elements.
-	STATE_ACTIVE           = 0x00000004,
+	STATE_ACTIVE = 0x00000004,
 	/// Element is focused.
-	STATE_FOCUS            = 0x00000008,
+	STATE_FOCUS = 0x00000008,
 
 	/// Element was visited.
 	///
 	/// For example, a link that was clicked.
-	STATE_VISITED          = 0x00000010,
+	STATE_VISITED = 0x00000010,
 	/// Current (hot) item.
-	STATE_CURRENT          = 0x00000020,
+	STATE_CURRENT = 0x00000020,
 	/// Element is checked (or selected).
-	STATE_CHECKED          = 0x00000040,
+	STATE_CHECKED = 0x00000040,
 	/// Element is disabled.
-	STATE_DISABLED         = 0x00000080,
+	STATE_DISABLED = 0x00000080,
 	/// Readonly input element.
-	STATE_READONLY         = 0x00000100,
+	STATE_READONLY = 0x00000100,
 
 	/// Expanded state - e.g. nodes in tree view.
 	///
 	/// Mutually exclusive with `STATE_COLLAPSED`.
-	STATE_EXPANDED         = 0x00000200,
+	STATE_EXPANDED = 0x00000200,
 
 	/// Collapsed state - e.g. nodes in tree view.
 	///
 	/// Mutually exclusive with `STATE_EXPANDED`.
-	STATE_COLLAPSED        = 0x00000400,
+	STATE_COLLAPSED = 0x00000400,
 
 	/// One of fore/back images was requested but is not delivered.
-	STATE_INCOMPLETE       = 0x00000800,
+	STATE_INCOMPLETE = 0x00000800,
 	/// Is animating currently.
-	STATE_ANIMATING        = 0x00001000,
+	STATE_ANIMATING = 0x00001000,
 	/// Will accept focus.
-	STATE_FOCUSABLE        = 0x00002000,
+	STATE_FOCUSABLE = 0x00002000,
 
 	/// Anchor in selection (used with current in selects).
-	STATE_ANCHOR           = 0x00004000,
+	STATE_ANCHOR = 0x00004000,
 	/// This is a synthetic element - i.e. don't emit it's head/tail.
-	STATE_SYNTHETIC        = 0x00008000,
+	STATE_SYNTHETIC = 0x00008000,
 	/// A popup element is shown for this particular element.
-	STATE_OWNS_POPUP       = 0x00010000,
+	STATE_OWNS_POPUP = 0x00010000,
 
 	/// Focus gained by tab traversal.
-	STATE_TABFOCUS         = 0x00020000,
+	STATE_TABFOCUS = 0x00020000,
 
 	/// Element is empty.
 	///
 	/// i.e. the element has no text content nor children nodes.
 	///
 	/// If element has a behavior attached then the behavior is responsible for the value of this flag.
-	STATE_EMPTY            = 0x00040000,
+	STATE_EMPTY = 0x00040000,
 
 	/// Busy or loading.
-	STATE_BUSY             = 0x00080000,
+	STATE_BUSY = 0x00080000,
 
 	/// Drag over the block that can accept it (so is a current drop target).
 	///
 	/// Flag is set for the drop target block.
-	STATE_DRAG_OVER        = 0x00100000,
+	STATE_DRAG_OVER = 0x00100000,
 	/// Active drop target.
-	STATE_DROP_TARGET      = 0x00200000,
+	STATE_DROP_TARGET = 0x00200000,
 	/// Dragging/moving - the flag is set for the moving block.
-	STATE_MOVING           = 0x00400000,
+	STATE_MOVING = 0x00400000,
 	/// Dragging/copying - the flag is set for the copying block.
-	STATE_COPYING          = 0x00800000,
+	STATE_COPYING = 0x00800000,
 	/// Element that is a drag source.
-	STATE_DRAG_SOURCE      = 0x01000000,
+	STATE_DRAG_SOURCE = 0x01000000,
 	/// Element is drop marker.
-	STATE_DROP_MARKER      = 0x02000000,
+	STATE_DROP_MARKER = 0x02000000,
 
 	/// Close to `STATE_ACTIVE` but has wider life span.
 	///
 	/// E.g. in `MOUSE_UP` it is still on;
 	/// so behavior can check it in `MOUSE_UP` to discover the `CLICK` condition.
-	STATE_PRESSED          = 0x04000000,
+	STATE_PRESSED = 0x04000000,
 
 	/// This element is out of flow.
-	STATE_POPUP            = 0x08000000,
+	STATE_POPUP = 0x08000000,
 
 	/// The element or one of its containers has `dir=ltr` declared.
-	STATE_IS_LTR           = 0x10000000,
+	STATE_IS_LTR = 0x10000000,
 	/// The element or one of its containers has `dir=rtl` declared.
-	STATE_IS_RTL           = 0x20000000,
+	STATE_IS_RTL = 0x20000000,
 
 	/// Element is ready (behavior has finished initialization).
-	STATE_READY            = 0x40000000,
+	STATE_READY = 0x40000000,
 }
 
 /// Flags can be OR'ed.
 impl ::std::ops::BitOr for ELEMENT_STATE_BITS {
-  type Output = ELEMENT_STATE_BITS;
-  fn bitor(self, rhs: Self::Output) -> Self::Output {
-    let rn = (self as UINT) | (rhs as UINT);
-    unsafe { ::std::mem::transmute(rn) }
-  }
+	type Output = ELEMENT_STATE_BITS;
+	fn bitor(self, rhs: Self::Output) -> Self::Output {
+		let rn = (self as UINT) | (rhs as UINT);
+		unsafe { ::std::mem::transmute(rn) }
+	}
 }
 
 /// Flags can be AND'ed.
 impl ::std::ops::BitAnd for ELEMENT_STATE_BITS {
-  type Output = ELEMENT_STATE_BITS;
-  fn bitand(self, rhs: Self::Output) -> Self::Output {
-    let rn = (self as UINT) & (rhs as UINT);
-    unsafe { ::std::mem::transmute(rn) }
-  }
+	type Output = ELEMENT_STATE_BITS;
+	fn bitand(self, rhs: Self::Output) -> Self::Output {
+		let rn = (self as UINT) & (rhs as UINT);
+		unsafe { ::std::mem::transmute(rn) }
+	}
 }
 
-pub type SciterElementCallback = extern "system" fn (he: HELEMENT, param: LPVOID) -> BOOL;
+pub type SciterElementCallback = extern "system" fn(he: HELEMENT, param: LPVOID) -> BOOL;
 
-pub type ELEMENT_COMPARATOR = extern "system" fn (he1: HELEMENT, he2: HELEMENT, param: LPVOID) -> INT;
+pub type ELEMENT_COMPARATOR = extern "system" fn(he1: HELEMENT, he2: HELEMENT, param: LPVOID) -> INT;

--- a/src/capi/scgraphics.rs
+++ b/src/capi/scgraphics.rs
@@ -3,14 +3,30 @@
 #![allow(non_camel_case_types, non_snake_case)]
 #![allow(dead_code)]
 
-use capi::scdom::HELEMENT;
-use capi::sctypes::{BOOL, LPCBYTE, LPCWSTR, LPVOID, UINT};
-use capi::scvalue::VALUE;
+use crate::capi::scdom::HELEMENT;
+use crate::capi::sctypes::{BOOL, LPCBYTE, LPCWSTR, LPVOID, UINT};
+use crate::capi::scvalue::VALUE;
 
-MAKE_HANDLE!(#[doc = "Graphics native handle."] HGFX, _HGFX);
-MAKE_HANDLE!(#[doc = "Image native handle."] HIMG, _HIMG);
-MAKE_HANDLE!(#[doc = "Path native handle."] HPATH, _HPATH);
-MAKE_HANDLE!(#[doc = "Text native handle."] HTEXT, _HTEXT);
+MAKE_HANDLE!(
+	#[doc = "Graphics native handle."]
+	HGFX,
+	_HGFX
+);
+MAKE_HANDLE!(
+	#[doc = "Image native handle."]
+	HIMG,
+	_HIMG
+);
+MAKE_HANDLE!(
+	#[doc = "Path native handle."]
+	HPATH,
+	_HPATH
+);
+MAKE_HANDLE!(
+	#[doc = "Text native handle."]
+	HTEXT,
+	_HTEXT
+);
 
 pub type SC_REAL = f32;
 pub type SC_POS = SC_REAL;
@@ -19,21 +35,20 @@ pub type SC_ANGLE = SC_REAL;
 
 pub type SC_COLOR = u32;
 
-
 #[repr(C)]
 #[derive(Debug, PartialEq)]
 /// Type of the result value for Sciter Graphics functions.
 pub enum GRAPHIN_RESULT {
 	/// E.g. not enough memory.
-  PANIC = -1,
-  /// Success.
-  OK = 0,
-  /// Bad parameter.
-  BAD_PARAM = 1,
-  /// Operation failed, e.g. `restore()` without `save()`.
-  FAILURE = 2,
-  /// Platform does not support the requested feature.
-  NOTSUPPORTED = 3,
+	PANIC = -1,
+	/// Success.
+	OK = 0,
+	/// Bad parameter.
+	BAD_PARAM = 1,
+	/// Operation failed, e.g. `restore()` without `save()`.
+	FAILURE = 2,
+	/// Platform does not support the requested feature.
+	NOTSUPPORTED = 3,
 }
 
 impl std::error::Error for GRAPHIN_RESULT {}
@@ -44,309 +59,340 @@ impl std::fmt::Display for GRAPHIN_RESULT {
 	}
 }
 
-
 /// Path drawing mode.
 #[repr(C)]
 #[derive(Debug, PartialEq)]
 pub enum DRAW_PATH {
-  /// Draw without outline line.
-  FILL_ONLY = 1,
-  /// Draw outline without fill.
-  STROKE_ONLY = 2,
-  /// Draw outlined and filled path.
-  FILL_AND_STROKE = 3,
+	/// Draw without outline line.
+	FILL_ONLY = 1,
+	/// Draw outline without fill.
+	STROKE_ONLY = 2,
+	/// Draw outlined and filled path.
+	FILL_AND_STROKE = 3,
 }
 
 /// Line drawing join mode.
 #[repr(C)]
 #[derive(Debug, PartialEq)]
 pub enum LINE_JOIN {
-  /// Specifies a mitered join. This produces a sharp corner or a clipped corner,
-  /// depending on whether the length of the miter exceeds the miter limit (`10.0`).
-  MITER = 0,
-  /// Specifies a circular join. This produces a smooth, circular arc between the lines.
-  ROUND = 1,
-  /// Specifies a beveled join. This produces a diagonal corner.
-  BEVEL = 2,
-  /// Specifies a mitered join. This produces a sharp corner or a beveled corner,
-  /// depending on whether the length of the miter exceeds the miter limit (`10.0`).
-  MITER_OR_BEVEL = 3,
+	/// Specifies a mitered join. This produces a sharp corner or a clipped corner,
+	/// depending on whether the length of the miter exceeds the miter limit (`10.0`).
+	MITER = 0,
+	/// Specifies a circular join. This produces a smooth, circular arc between the lines.
+	ROUND = 1,
+	/// Specifies a beveled join. This produces a diagonal corner.
+	BEVEL = 2,
+	/// Specifies a mitered join. This produces a sharp corner or a beveled corner,
+	/// depending on whether the length of the miter exceeds the miter limit (`10.0`).
+	MITER_OR_BEVEL = 3,
 }
 
 /// Line drawing cap mode.
 #[repr(C)]
 #[derive(Debug, PartialEq)]
 pub enum LINE_CAP {
-  /// The ends of lines are squared off at the endpoints.
-  BUTT = 0,
-  /// The ends of lines are squared off by adding a box with an equal width
-  /// and half the height of the line's thickness.
-  SQUARE = 1,
-  /// The ends of lines are rounded.
-  ROUND = 2,
+	/// The ends of lines are squared off at the endpoints.
+	BUTT = 0,
+	/// The ends of lines are squared off by adding a box with an equal width
+	/// and half the height of the line's thickness.
+	SQUARE = 1,
+	/// The ends of lines are rounded.
+	ROUND = 2,
 }
 
 #[repr(C)]
 #[derive(Debug, PartialEq)]
 pub enum IMAGE_ENCODING {
-  RAW, // [a,b,g,r,a,b,g,r,...] vector
-  PNG,
-  JPG,
-  WEBP,
+	RAW, // [a,b,g,r,a,b,g,r,...] vector
+	PNG,
+	JPG,
+	WEBP,
 }
 
 #[repr(C)]
 #[derive(Debug)]
 pub struct SC_COLOR_STOP {
-  pub color: SC_COLOR,
-  pub offset: f32,
+	pub color: SC_COLOR,
+	pub offset: f32,
 }
-
 
 #[repr(C)]
 #[allow(missing_docs)]
 pub struct SciterGraphicsAPI {
-  // image primitives
-  pub imageCreate: extern "system" fn(poutImg: &mut HIMG, width: UINT, height: UINT, withAlpha: BOOL) -> GRAPHIN_RESULT,
+	// image primitives
+	pub imageCreate: extern "system" fn(poutImg: &mut HIMG, width: UINT, height: UINT, withAlpha: BOOL) -> GRAPHIN_RESULT,
 
-  // construct image from B[n+0],G[n+1],R[n+2],A[n+3] data.
-  // Size of pixmap data is pixmapWidth*pixmapHeight*4
-  pub imageCreateFromPixmap:
-    extern "system" fn(poutImg: &mut HIMG, pixmapWidth: UINT, pixmapHeight: UINT, withAlpha: BOOL, pixmap: LPCBYTE) -> GRAPHIN_RESULT,
+	// construct image from B[n+0],G[n+1],R[n+2],A[n+3] data.
+	// Size of pixmap data is pixmapWidth*pixmapHeight*4
+	pub imageCreateFromPixmap:
+		extern "system" fn(poutImg: &mut HIMG, pixmapWidth: UINT, pixmapHeight: UINT, withAlpha: BOOL, pixmap: LPCBYTE) -> GRAPHIN_RESULT,
 
-  pub imageAddRef: extern "system" fn(himg: HIMG) -> GRAPHIN_RESULT,
+	pub imageAddRef: extern "system" fn(himg: HIMG) -> GRAPHIN_RESULT,
 
-  pub imageRelease: extern "system" fn(himg: HIMG) -> GRAPHIN_RESULT,
+	pub imageRelease: extern "system" fn(himg: HIMG) -> GRAPHIN_RESULT,
 
-  pub imageGetInfo: extern "system" fn(himg: HIMG, width: &mut UINT, height: &mut UINT, usesAlpha: &mut BOOL) -> GRAPHIN_RESULT,
+	pub imageGetInfo: extern "system" fn(himg: HIMG, width: &mut UINT, height: &mut UINT, usesAlpha: &mut BOOL) -> GRAPHIN_RESULT,
 
-  pub imageClear: extern "system" fn(himg: HIMG, byColor: SC_COLOR) -> GRAPHIN_RESULT,
+	pub imageClear: extern "system" fn(himg: HIMG, byColor: SC_COLOR) -> GRAPHIN_RESULT,
 
-  pub imageLoad: extern "system" fn(bytes: LPCBYTE, num_bytes: UINT, pout_img: &mut HIMG) -> GRAPHIN_RESULT, // load png/jpeg/etc. image from stream of bytes
+	pub imageLoad: extern "system" fn(bytes: LPCBYTE, num_bytes: UINT, pout_img: &mut HIMG) -> GRAPHIN_RESULT, // load png/jpeg/etc. image from stream of bytes
 
-  pub imageSave: extern "system" fn(himg: HIMG, pfn: ImageWriteFunction, prm: LPVOID, encoding: IMAGE_ENCODING, quality: UINT) -> GRAPHIN_RESULT,
+	pub imageSave:
+		extern "system" fn(himg: HIMG, pfn: ImageWriteFunction, prm: LPVOID, encoding: IMAGE_ENCODING, quality: UINT) -> GRAPHIN_RESULT,
 
-  // SECTION: graphics primitives and drawing operations
+	// SECTION: graphics primitives and drawing operations
 
-  // create SC_COLOR value
-  pub RGBA: extern "system" fn(red: UINT, green: UINT, blue: UINT, alpha: UINT) -> SC_COLOR,
+	// create SC_COLOR value
+	pub RGBA: extern "system" fn(red: UINT, green: UINT, blue: UINT, alpha: UINT) -> SC_COLOR,
 
-  pub gCreate: extern "system" fn(img: HIMG, pout_gfx: &mut HGFX) -> GRAPHIN_RESULT,
+	pub gCreate: extern "system" fn(img: HIMG, pout_gfx: &mut HGFX) -> GRAPHIN_RESULT,
 
-  pub gAddRef: extern "system" fn(gfx: HGFX) -> GRAPHIN_RESULT,
+	pub gAddRef: extern "system" fn(gfx: HGFX) -> GRAPHIN_RESULT,
 
-  pub gRelease: extern "system" fn(gfx: HGFX) -> GRAPHIN_RESULT,
+	pub gRelease: extern "system" fn(gfx: HGFX) -> GRAPHIN_RESULT,
 
-  // Draws line from x1,y1 to x2,y2 using current lineColor and lineGradient.
-  pub gLine: extern "system" fn(hgfx: HGFX, x1: SC_POS, y1: SC_POS, x2: SC_POS, y2: SC_POS) -> GRAPHIN_RESULT,
+	// Draws line from x1,y1 to x2,y2 using current lineColor and lineGradient.
+	pub gLine: extern "system" fn(hgfx: HGFX, x1: SC_POS, y1: SC_POS, x2: SC_POS, y2: SC_POS) -> GRAPHIN_RESULT,
 
-  // Draws rectangle using current lineColor/lineGradient and fillColor/fillGradient with (optional) rounded corners.
-  pub gRectangle: extern "system" fn(hgfx: HGFX, x1: SC_POS, y1: SC_POS, x2: SC_POS, y2: SC_POS) -> GRAPHIN_RESULT,
+	// Draws rectangle using current lineColor/lineGradient and fillColor/fillGradient with (optional) rounded corners.
+	pub gRectangle: extern "system" fn(hgfx: HGFX, x1: SC_POS, y1: SC_POS, x2: SC_POS, y2: SC_POS) -> GRAPHIN_RESULT,
 
-  // Draws rounded rectangle using current lineColor/lineGradient and fillColor/fillGradient with (optional) rounded corners.
-  pub gRoundedRectangle: extern "system" fn(
-    hgfx: HGFX,
-    x1: SC_POS,
-    y1: SC_POS,
-    x2: SC_POS,
-    y2: SC_POS,
-    radii8: *const SC_DIM,
-  ) -> GRAPHIN_RESULT,
+	// Draws rounded rectangle using current lineColor/lineGradient and fillColor/fillGradient with (optional) rounded corners.
+	pub gRoundedRectangle:
+		extern "system" fn(hgfx: HGFX, x1: SC_POS, y1: SC_POS, x2: SC_POS, y2: SC_POS, radii8: *const SC_DIM) -> GRAPHIN_RESULT,
 
-  // Draws circle or ellipse using current lineColor/lineGradient and fillColor/fillGradient.
-  pub gEllipse: extern "system" fn(hgfx: HGFX, x: SC_POS, y: SC_POS, rx: SC_DIM, ry: SC_DIM) -> GRAPHIN_RESULT,
+	// Draws circle or ellipse using current lineColor/lineGradient and fillColor/fillGradient.
+	pub gEllipse: extern "system" fn(hgfx: HGFX, x: SC_POS, y: SC_POS, rx: SC_DIM, ry: SC_DIM) -> GRAPHIN_RESULT,
 
-  // Draws closed arc using current lineColor/lineGradient and fillColor/fillGradient.
-  pub gArc:
-    extern "system" fn(hgfx: HGFX, x: SC_POS, y: SC_POS, rx: SC_POS, ry: SC_POS, start: SC_ANGLE, sweep: SC_ANGLE) -> GRAPHIN_RESULT,
+	// Draws closed arc using current lineColor/lineGradient and fillColor/fillGradient.
+	pub gArc:
+		extern "system" fn(hgfx: HGFX, x: SC_POS, y: SC_POS, rx: SC_POS, ry: SC_POS, start: SC_ANGLE, sweep: SC_ANGLE) -> GRAPHIN_RESULT,
 
-  // Draws star.
-  pub gStar: extern "system" fn(hgfx: HGFX, x: SC_POS, y: SC_POS, r1: SC_DIM, r2: SC_DIM, start: SC_ANGLE, rays: UINT) -> GRAPHIN_RESULT,
+	// Draws star.
+	pub gStar: extern "system" fn(hgfx: HGFX, x: SC_POS, y: SC_POS, r1: SC_DIM, r2: SC_DIM, start: SC_ANGLE, rays: UINT) -> GRAPHIN_RESULT,
 
-  // Closed polygon.
-  pub gPolygon: extern "system" fn(hgfx: HGFX, xy: *const SC_POS, num_points: UINT) -> GRAPHIN_RESULT,
+	// Closed polygon.
+	pub gPolygon: extern "system" fn(hgfx: HGFX, xy: *const SC_POS, num_points: UINT) -> GRAPHIN_RESULT,
 
-  // Polyline.
-  pub gPolyline: extern "system" fn(hgfx: HGFX, xy: *const SC_POS, num_points: UINT) -> GRAPHIN_RESULT,
+	// Polyline.
+	pub gPolyline: extern "system" fn(hgfx: HGFX, xy: *const SC_POS, num_points: UINT) -> GRAPHIN_RESULT,
 
-  // SECTION: Path operations
-  pub pathCreate: extern "system" fn(path: &mut HPATH) -> GRAPHIN_RESULT,
+	// SECTION: Path operations
+	pub pathCreate: extern "system" fn(path: &mut HPATH) -> GRAPHIN_RESULT,
 
-  pub pathAddRef: extern "system" fn(path: HPATH) -> GRAPHIN_RESULT,
+	pub pathAddRef: extern "system" fn(path: HPATH) -> GRAPHIN_RESULT,
 
-  pub pathRelease: extern "system" fn(path: HPATH) -> GRAPHIN_RESULT,
+	pub pathRelease: extern "system" fn(path: HPATH) -> GRAPHIN_RESULT,
 
-  pub pathMoveTo: extern "system" fn(path: HPATH, x: SC_POS, y: SC_POS, relative: BOOL) -> GRAPHIN_RESULT,
+	pub pathMoveTo: extern "system" fn(path: HPATH, x: SC_POS, y: SC_POS, relative: BOOL) -> GRAPHIN_RESULT,
 
-  pub pathLineTo: extern "system" fn(path: HPATH, x: SC_POS, y: SC_POS, relative: BOOL) -> GRAPHIN_RESULT,
+	pub pathLineTo: extern "system" fn(path: HPATH, x: SC_POS, y: SC_POS, relative: BOOL) -> GRAPHIN_RESULT,
 
-  pub pathArcTo: extern "system" fn(
-    path: HPATH,
-    x: SC_POS,
-    y: SC_POS,
-    angle: SC_ANGLE,
-    rx: SC_DIM,
-    ry: SC_DIM,
-    is_large_arc: BOOL,
-    clockwise: BOOL,
-    relative: BOOL,
-  ) -> GRAPHIN_RESULT,
+	pub pathArcTo: extern "system" fn(
+		path: HPATH,
+		x: SC_POS,
+		y: SC_POS,
+		angle: SC_ANGLE,
+		rx: SC_DIM,
+		ry: SC_DIM,
+		is_large_arc: BOOL,
+		clockwise: BOOL,
+		relative: BOOL,
+	) -> GRAPHIN_RESULT,
 
-  pub pathQuadraticCurveTo: extern "system" fn(path: HPATH, xc: SC_POS, yc: SC_POS, x: SC_POS, y: SC_POS, relative: BOOL) -> GRAPHIN_RESULT,
+	pub pathQuadraticCurveTo: extern "system" fn(path: HPATH, xc: SC_POS, yc: SC_POS, x: SC_POS, y: SC_POS, relative: BOOL) -> GRAPHIN_RESULT,
 
-  pub pathBezierCurveTo:
-    extern "system" fn(path: HPATH, xc1: SC_POS, yc1: SC_POS, xc2: SC_POS, yc2: SC_POS, x: SC_POS, y: SC_POS, relative: BOOL)
-      -> GRAPHIN_RESULT,
+	pub pathBezierCurveTo: extern "system" fn(
+		path: HPATH,
+		xc1: SC_POS,
+		yc1: SC_POS,
+		xc2: SC_POS,
+		yc2: SC_POS,
+		x: SC_POS,
+		y: SC_POS,
+		relative: BOOL,
+	) -> GRAPHIN_RESULT,
 
-  pub pathClosePath: extern "system" fn(path: HPATH) -> GRAPHIN_RESULT,
+	pub pathClosePath: extern "system" fn(path: HPATH) -> GRAPHIN_RESULT,
 
-  pub gDrawPath: extern "system" fn(hgfx: HGFX, path: HPATH, dpm: DRAW_PATH) -> GRAPHIN_RESULT,
+	pub gDrawPath: extern "system" fn(hgfx: HGFX, path: HPATH, dpm: DRAW_PATH) -> GRAPHIN_RESULT,
 
-  // end of path opearations
+	// end of path opearations
 
-// SECTION: affine tranformations:
-  pub gRotate: extern "system" fn(hgfx: HGFX, radians: SC_ANGLE, cx: Option<&SC_POS>, cy: Option<&SC_POS>) -> GRAPHIN_RESULT,
+	// SECTION: affine tranformations:
+	pub gRotate: extern "system" fn(hgfx: HGFX, radians: SC_ANGLE, cx: Option<&SC_POS>, cy: Option<&SC_POS>) -> GRAPHIN_RESULT,
+
+	pub gTranslate: extern "system" fn(hgfx: HGFX, cx: SC_POS, cy: SC_POS) -> GRAPHIN_RESULT,
+
+	pub gScale: extern "system" fn(hgfx: HGFX, x: SC_DIM, y: SC_DIM) -> GRAPHIN_RESULT,
+
+	pub gSkew: extern "system" fn(hgfx: HGFX, dx: SC_DIM, dy: SC_DIM) -> GRAPHIN_RESULT,
+
+	// all above in one shot
+	pub gTransform:
+		extern "system" fn(hgfx: HGFX, m11: SC_POS, m12: SC_POS, m21: SC_POS, m22: SC_POS, dx: SC_POS, dy: SC_POS) -> GRAPHIN_RESULT,
+
+	// end of affine tranformations.
+
+	// SECTION: state save/restore
+	pub gStateSave: extern "system" fn(hgfx: HGFX) -> GRAPHIN_RESULT,
+
+	pub gStateRestore: extern "system" fn(hgfx: HGFX) -> GRAPHIN_RESULT,
+
+	// end of state save/restore
+
+	// SECTION: drawing attributes
+
+	// set line width for subsequent drawings.
+	pub gLineWidth: extern "system" fn(hgfx: HGFX, width: SC_DIM) -> GRAPHIN_RESULT,
+
+	pub gLineJoin: extern "system" fn(hgfx: HGFX, join_type: LINE_JOIN) -> GRAPHIN_RESULT,
+
+	pub gLineCap: extern "system" fn(hgfx: HGFX, cap_type: LINE_CAP) -> GRAPHIN_RESULT,
+
+	// SC_COLOR for solid lines/strokes
+	pub gLineColor: extern "system" fn(hgfx: HGFX, color: SC_COLOR) -> GRAPHIN_RESULT,
+
+	// SC_COLOR for solid fills
+	pub gFillColor: extern "system" fn(hgfx: HGFX, color: SC_COLOR) -> GRAPHIN_RESULT,
+
+	// setup parameters of linear gradient of lines.
+	pub gLineGradientLinear: extern "system" fn(
+		hgfx: HGFX,
+		x1: SC_POS,
+		y1: SC_POS,
+		x2: SC_POS,
+		y2: SC_POS,
+		stops: *const SC_COLOR_STOP,
+		nstops: UINT,
+	) -> GRAPHIN_RESULT,
+
+	// setup parameters of linear gradient of fills.
+	pub gFillGradientLinear: extern "system" fn(
+		hgfx: HGFX,
+		x1: SC_POS,
+		y1: SC_POS,
+		x2: SC_POS,
+		y2: SC_POS,
+		stops: *const SC_COLOR_STOP,
+		nstops: UINT,
+	) -> GRAPHIN_RESULT,
+
+	// setup parameters of line gradient radial fills.
+	pub gLineGradientRadial: extern "system" fn(
+		hgfx: HGFX,
+		x: SC_POS,
+		y: SC_POS,
+		rx: SC_DIM,
+		ry: SC_DIM,
+		stops: *const SC_COLOR_STOP,
+		nstops: UINT,
+	) -> GRAPHIN_RESULT,
+
+	// setup parameters of gradient radial fills.
+	pub gFillGradientRadial: extern "system" fn(
+		hgfx: HGFX,
+		x: SC_POS,
+		y: SC_POS,
+		rx: SC_DIM,
+		ry: SC_DIM,
+		stops: *const SC_COLOR_STOP,
+		nstops: UINT,
+	) -> GRAPHIN_RESULT,
 
-  pub gTranslate: extern "system" fn(hgfx: HGFX, cx: SC_POS, cy: SC_POS) -> GRAPHIN_RESULT,
+	pub gFillMode: extern "system" fn(hgfx: HGFX, even_odd: BOOL) -> GRAPHIN_RESULT,
 
-  pub gScale: extern "system" fn(hgfx: HGFX, x: SC_DIM, y: SC_DIM) -> GRAPHIN_RESULT,
+	// SECTION: text
 
-  pub gSkew: extern "system" fn(hgfx: HGFX, dx: SC_DIM, dy: SC_DIM) -> GRAPHIN_RESULT,
+	// create text layout for host element
+	pub textCreateForElement:
+		extern "system" fn(ptext: &mut HTEXT, text: LPCWSTR, textLength: UINT, he: HELEMENT, classNameOrNull: LPCWSTR) -> GRAPHIN_RESULT,
 
-  // all above in one shot
-  pub gTransform:
-    extern "system" fn(hgfx: HGFX, m11: SC_POS, m12: SC_POS, m21: SC_POS, m22: SC_POS, dx: SC_POS, dy: SC_POS) -> GRAPHIN_RESULT,
+	// create text layout using explicit style declaration
+	pub textCreateForElementAndStyle: extern "system" fn(
+		ptext: &mut HTEXT,
+		text: LPCWSTR,
+		textLength: UINT,
+		he: HELEMENT,
+		style: LPCWSTR,
+		styleLength: UINT,
+	) -> GRAPHIN_RESULT,
 
-  // end of affine tranformations.
+	// since 4.1.10
+	pub textAddRef: extern "system" fn(text: HTEXT) -> GRAPHIN_RESULT,
 
-// SECTION: state save/restore
-  pub gStateSave: extern "system" fn(hgfx: HGFX) -> GRAPHIN_RESULT,
+	// since 4.1.10
+	pub textRelease: extern "system" fn(text: HTEXT) -> GRAPHIN_RESULT,
 
-  pub gStateRestore: extern "system" fn(hgfx: HGFX) -> GRAPHIN_RESULT,
+	pub textGetMetrics: extern "system" fn(
+		text: HTEXT,
+		minWidth: &mut SC_DIM,
+		maxWidth: &mut SC_DIM,
+		height: &mut SC_DIM,
+		ascent: &mut SC_DIM,
+		descent: &mut SC_DIM,
+		nLines: &mut UINT,
+	) -> GRAPHIN_RESULT,
 
-  // end of state save/restore
+	pub textSetBox: extern "system" fn(text: HTEXT, width: SC_DIM, height: SC_DIM) -> GRAPHIN_RESULT,
 
-// SECTION: drawing attributes
+	// draw text with position (1..9 on MUMPAD) at px,py
+	// Ex: gDrawText(100,100,5) will draw text box with its center at 100,100 px
+	pub gDrawText: extern "system" fn(hgfx: HGFX, text: HTEXT, px: SC_POS, py: SC_POS, position: UINT) -> GRAPHIN_RESULT,
 
-  // set line width for subsequent drawings.
-  pub gLineWidth: extern "system" fn(hgfx: HGFX, width: SC_DIM) -> GRAPHIN_RESULT,
+	// SECTION: image rendering
 
-  pub gLineJoin: extern "system" fn(hgfx: HGFX, join_type: LINE_JOIN) -> GRAPHIN_RESULT,
+	// draws img onto the graphics surface with current transformation applied (scale, rotation).
+	#[allow(clippy::type_complexity)]
+	pub gDrawImage: extern "system" fn(
+		hgfx: HGFX,
+		himg: HIMG,
+		x: SC_POS,
+		y: SC_POS,
+		w: Option<&SC_DIM>,
+		h: Option<&SC_DIM>,
+		ix: Option<&UINT>,
+		iy: Option<&UINT>,
+		iw: Option<&UINT>,
+		ih: Option<&UINT>,
+		opacity: Option<&f32>,
+	) -> GRAPHIN_RESULT,
 
-  pub gLineCap: extern "system" fn(hgfx: HGFX, cap_type: LINE_CAP) -> GRAPHIN_RESULT,
+	// SECTION: coordinate space
+	pub gWorldToScreen: extern "system" fn(hgfx: HGFX, inout_x: &mut SC_POS, inout_y: &mut SC_POS) -> GRAPHIN_RESULT,
 
-  // SC_COLOR for solid lines/strokes
-  pub gLineColor: extern "system" fn(hgfx: HGFX, color: SC_COLOR) -> GRAPHIN_RESULT,
+	pub gScreenToWorld: extern "system" fn(hgfx: HGFX, inout_x: &mut SC_POS, inout_y: &mut SC_POS) -> GRAPHIN_RESULT,
 
-  // SC_COLOR for solid fills
-  pub gFillColor: extern "system" fn(hgfx: HGFX, color: SC_COLOR) -> GRAPHIN_RESULT,
+	// SECTION: clipping
+	pub gPushClipBox: extern "system" fn(hgfx: HGFX, x1: SC_POS, y1: SC_POS, x2: SC_POS, y2: SC_POS, opacity: f32) -> GRAPHIN_RESULT,
 
-  // setup parameters of linear gradient of lines.
-  pub gLineGradientLinear:
-    extern "system" fn(hgfx: HGFX, x1: SC_POS, y1: SC_POS, x2: SC_POS, y2: SC_POS, stops: *const SC_COLOR_STOP, nstops: UINT)
-      -> GRAPHIN_RESULT,
+	pub gPushClipPath: extern "system" fn(hgfx: HGFX, hpath: HPATH, opacity: f32) -> GRAPHIN_RESULT,
 
-  // setup parameters of linear gradient of fills.
-  pub gFillGradientLinear:
-    extern "system" fn(hgfx: HGFX, x1: SC_POS, y1: SC_POS, x2: SC_POS, y2: SC_POS, stops: *const SC_COLOR_STOP, nstops: UINT)
-      -> GRAPHIN_RESULT,
+	// pop clip layer previously set by gPushClipBox or gPushClipPath
+	pub gPopClip: extern "system" fn(hgfx: HGFX) -> GRAPHIN_RESULT,
 
-  // setup parameters of line gradient radial fills.
-  pub gLineGradientRadial:
-    extern "system" fn(hgfx: HGFX, x: SC_POS, y: SC_POS, rx: SC_DIM, ry: SC_DIM, stops: *const SC_COLOR_STOP, nstops: UINT)
-      -> GRAPHIN_RESULT,
+	// image painter
+	pub imagePaint: extern "system" fn(himg: HIMG, pPainter: ImagePaintFunction, prm: LPVOID) -> GRAPHIN_RESULT, // paint on image using graphics
 
-  // setup parameters of gradient radial fills.
-  pub gFillGradientRadial:
-    extern "system" fn(hgfx: HGFX, x: SC_POS, y: SC_POS, rx: SC_DIM, ry: SC_DIM, stops: *const SC_COLOR_STOP, nstops: UINT)
-      -> GRAPHIN_RESULT,
+	// VALUE interface
+	pub vWrapGfx: extern "system" fn(hgfx: HGFX, toValue: *mut VALUE) -> GRAPHIN_RESULT,
 
-  pub gFillMode: extern "system" fn(hgfx: HGFX, even_odd: BOOL) -> GRAPHIN_RESULT,
+	pub vWrapImage: extern "system" fn(himg: HIMG, toValue: *mut VALUE) -> GRAPHIN_RESULT,
 
-  // SECTION: text
+	pub vWrapPath: extern "system" fn(hpath: HPATH, toValue: *mut VALUE) -> GRAPHIN_RESULT,
 
-  // create text layout for host element
-  pub textCreateForElement: extern "system" fn(ptext: &mut HTEXT, text: LPCWSTR, textLength: UINT, he: HELEMENT, classNameOrNull: LPCWSTR) -> GRAPHIN_RESULT,
+	pub vWrapText: extern "system" fn(htext: HTEXT, toValue: *mut VALUE) -> GRAPHIN_RESULT,
 
-  // create text layout using explicit style declaration
-  pub textCreateForElementAndStyle:
-    extern "system" fn(ptext: &mut HTEXT, text: LPCWSTR, textLength: UINT, he: HELEMENT, style: LPCWSTR, styleLength: UINT) -> GRAPHIN_RESULT,
+	pub vUnWrapGfx: extern "system" fn(fromValue: *const VALUE, phgfx: &mut HGFX) -> GRAPHIN_RESULT,
 
-  // since 4.1.10
-  pub textAddRef: extern "system" fn(text: HTEXT) -> GRAPHIN_RESULT,
+	pub vUnWrapImage: extern "system" fn(fromValue: *const VALUE, phimg: &mut HIMG) -> GRAPHIN_RESULT,
 
-  // since 4.1.10
-  pub textRelease: extern "system" fn(text: HTEXT) -> GRAPHIN_RESULT,
+	pub vUnWrapPath: extern "system" fn(fromValue: *const VALUE, phpath: &mut HPATH) -> GRAPHIN_RESULT,
 
-  pub textGetMetrics: extern "system" fn(
-    text: HTEXT,
-    minWidth: &mut SC_DIM,
-    maxWidth: &mut SC_DIM,
-    height: &mut SC_DIM,
-    ascent: &mut SC_DIM,
-    descent: &mut SC_DIM,
-    nLines: &mut UINT,
-  ) -> GRAPHIN_RESULT,
-
-  pub textSetBox: extern "system" fn(text: HTEXT, width: SC_DIM, height: SC_DIM) -> GRAPHIN_RESULT,
-
-  // draw text with position (1..9 on MUMPAD) at px,py
-  // Ex: gDrawText(100,100,5) will draw text box with its center at 100,100 px
-  pub gDrawText: extern "system" fn(hgfx: HGFX, text: HTEXT, px: SC_POS, py: SC_POS, position: UINT) -> GRAPHIN_RESULT,
-
-  // SECTION: image rendering
-
-  // draws img onto the graphics surface with current transformation applied (scale, rotation).
-  #[allow(clippy::type_complexity)]
-  pub gDrawImage: extern "system" fn(
-    hgfx: HGFX,
-    himg: HIMG,
-    x: SC_POS,
-    y: SC_POS,
-    w: Option<&SC_DIM>,
-    h: Option<&SC_DIM>,
-    ix: Option<&UINT>,
-    iy: Option<&UINT>,
-    iw: Option<&UINT>,
-    ih: Option<&UINT>,
-    opacity: Option<&f32>,
-  ) -> GRAPHIN_RESULT,
-
-  // SECTION: coordinate space
-  pub gWorldToScreen: extern "system" fn(hgfx: HGFX, inout_x: &mut SC_POS, inout_y: &mut SC_POS) -> GRAPHIN_RESULT,
-
-  pub gScreenToWorld: extern "system" fn(hgfx: HGFX, inout_x: &mut SC_POS, inout_y: &mut SC_POS) -> GRAPHIN_RESULT,
-
-  // SECTION: clipping
-  pub gPushClipBox: extern "system" fn(hgfx: HGFX, x1: SC_POS, y1: SC_POS, x2: SC_POS, y2: SC_POS, opacity: f32) -> GRAPHIN_RESULT,
-
-  pub gPushClipPath: extern "system" fn(hgfx: HGFX, hpath: HPATH, opacity: f32) -> GRAPHIN_RESULT,
-
-  // pop clip layer previously set by gPushClipBox or gPushClipPath
-  pub gPopClip: extern "system" fn(hgfx: HGFX) -> GRAPHIN_RESULT,
-
-  // image painter
-  pub imagePaint: extern "system" fn(himg: HIMG, pPainter: ImagePaintFunction, prm: LPVOID) -> GRAPHIN_RESULT, // paint on image using graphics
-
-  // VALUE interface
-  pub vWrapGfx: extern "system" fn(hgfx: HGFX, toValue: *mut VALUE) -> GRAPHIN_RESULT,
-
-  pub vWrapImage: extern "system" fn(himg: HIMG, toValue: *mut VALUE) -> GRAPHIN_RESULT,
-
-  pub vWrapPath: extern "system" fn(hpath: HPATH, toValue: *mut VALUE) -> GRAPHIN_RESULT,
-
-  pub vWrapText: extern "system" fn(htext: HTEXT, toValue: *mut VALUE) -> GRAPHIN_RESULT,
-
-  pub vUnWrapGfx: extern "system" fn(fromValue: *const VALUE, phgfx: &mut HGFX) -> GRAPHIN_RESULT,
-
-  pub vUnWrapImage: extern "system" fn(fromValue: *const VALUE, phimg: &mut HIMG) -> GRAPHIN_RESULT,
-
-  pub vUnWrapPath: extern "system" fn(fromValue: *const VALUE, phpath: &mut HPATH) -> GRAPHIN_RESULT,
-
-  pub vUnWrapText: extern "system" fn(fromValue: *const VALUE, phtext: &mut HTEXT) -> GRAPHIN_RESULT,
+	pub vUnWrapText: extern "system" fn(fromValue: *const VALUE, phtext: &mut HTEXT) -> GRAPHIN_RESULT,
 
 	// since 4.4.3.20
-  pub gFlush: extern "system" fn(hgfx: HGFX) -> GRAPHIN_RESULT,
+	pub gFlush: extern "system" fn(hgfx: HGFX) -> GRAPHIN_RESULT,
 }
 
 pub type ImageWriteFunction = extern "system" fn(prm: LPVOID, data: LPCBYTE, data_length: UINT);

--- a/src/capi/schandler.rs
+++ b/src/capi/schandler.rs
@@ -2,7 +2,7 @@
 
 #![allow(dead_code)]
 
-use capi::sctypes::{LPCVOID, LPVOID};
+use crate::capi::sctypes::{LPCVOID, LPVOID};
 
 type Opaque = LPCVOID;
 
@@ -79,7 +79,7 @@ impl NativeHandler {
 		let pobj = param as *mut T;
 		if !pobj.is_null() {
 			// and drop it
-			unsafe { Box::from_raw(pobj) };
+			unsafe { let _ = Box::from_raw(pobj); };
 		}
 	}
 }

--- a/src/capi/scmsg.rs
+++ b/src/capi/scmsg.rs
@@ -3,10 +3,10 @@
 #![allow(non_camel_case_types, non_snake_case)]
 #![allow(dead_code)]
 
-use capi::sctypes::*;
-use capi::scdef::{GFX_LAYER, ELEMENT_BITMAP_RECEIVER};
-use capi::scdom::HELEMENT;
-use capi::scbehavior::{MOUSE_BUTTONS, MOUSE_EVENTS, KEY_EVENTS, KEYBOARD_STATES};
+use crate::capi::sctypes::*;
+use crate::capi::scdef::{GFX_LAYER, ELEMENT_BITMAP_RECEIVER};
+use crate::capi::scdom::HELEMENT;
+use crate::capi::scbehavior::{MOUSE_BUTTONS, MOUSE_EVENTS, KEY_EVENTS, KEYBOARD_STATES};
 
 
 #[repr(C)]

--- a/src/capi/scom.rs
+++ b/src/capi/scom.rs
@@ -8,12 +8,11 @@ and https://sciter.com/developers/for-native-gui-programmers/sciter-object-model
 #![allow(non_snake_case, non_camel_case_types)]
 #![allow(dead_code)]
 
-use capi::sctypes::*;
-use capi::scvalue::VALUE;
+use crate::capi::sctypes::*;
+use crate::capi::scvalue::VALUE;
 
 /// An atom value that uniquely identifies the name being registered.
 pub type som_atom_t = u64;
-
 
 /// `som_asset_t` is a structure that a custom native object must be derived from.
 #[repr(C)]
@@ -45,7 +44,6 @@ pub(crate) struct som_asset_class_t {
 	pub get_passport: extern "C" fn(thing: *mut som_asset_t) -> *const som_passport_t,
 }
 
-
 /// Defines properties and methods of an asset.
 #[repr(C)]
 pub struct som_passport_t {
@@ -75,7 +73,6 @@ pub struct som_passport_t {
 	/// pst.n_properties = 2;
 	/// pst.properties = Box::into_raw(props) as *const _;
 	/// ```
-
 	pub properties: *const som_property_def_t,
 
 	/// Properties count.
@@ -130,7 +127,6 @@ impl Default for som_passport_t {
 	}
 }
 
-
 /// [`som_passport_t`](struct.som_passport_t.html#structfield.flags) flags.
 #[repr(u64)]
 #[derive(Debug, PartialOrd, PartialEq)]
@@ -143,7 +139,6 @@ pub enum som_passport_flags {
 	/// An asset may have new properties added by script.
 	EXTENDABLE = 1,
 }
-
 
 /// Property of an asset.
 #[repr(C)]

--- a/src/capi/screquest.rs
+++ b/src/capi/screquest.rs
@@ -7,11 +7,15 @@ functions and other load requests.
 
 #![allow(non_camel_case_types, non_snake_case)]
 
-use capi::sctypes::{UINT, LPVOID, LPCBYTE, LPCSTR, LPCWSTR};
-use capi::scdef::{LPCSTR_RECEIVER, LPCWSTR_RECEIVER, LPCBYTE_RECEIVER};
-pub use capi::scdef::RESOURCE_TYPE;
+pub use crate::capi::scdef::RESOURCE_TYPE;
+use crate::capi::scdef::{LPCBYTE_RECEIVER, LPCSTR_RECEIVER, LPCWSTR_RECEIVER};
+use crate::capi::sctypes::{LPCBYTE, LPCSTR, LPCWSTR, LPVOID, UINT};
 
-MAKE_HANDLE!(#[doc = "Request native handle."] HREQUEST, _HREQUEST);
+MAKE_HANDLE!(
+	#[doc = "Request native handle."]
+	HREQUEST,
+	_HREQUEST
+);
 
 #[repr(C)]
 #[derive(Debug, PartialEq)]
@@ -26,7 +30,7 @@ pub enum REQUEST_RESULT {
 	/// Operation failed, e.g. index out of bounds.
 	FAILURE = 2,
 	/// The platform does not support requested feature.
-  NOTSUPPORTED = 3,
+	NOTSUPPORTED = 3,
 }
 
 impl std::error::Error for REQUEST_RESULT {}
@@ -36,7 +40,6 @@ impl std::fmt::Display for REQUEST_RESULT {
 		write!(f, "{:?}", self)
 	}
 }
-
 
 #[repr(C)]
 #[derive(Debug, PartialEq)]
@@ -72,7 +75,6 @@ pub enum REQUEST_TYPE {
 	Post,
 }
 
-
 #[repr(C)]
 #[derive(Debug, PartialEq)]
 /// Completion state of a request.
@@ -92,93 +94,91 @@ pub struct REQUEST_PARAM {
 	pub value: LPCWSTR,
 }
 
-
 #[repr(C)]
 #[allow(missing_docs)]
-pub struct SciterRequestAPI
-{
-  /// a.k.a AddRef()
-  pub RequestUse: extern "system" fn (rq: HREQUEST) -> REQUEST_RESULT,
+pub struct SciterRequestAPI {
+	/// a.k.a AddRef()
+	pub RequestUse: extern "system" fn(rq: HREQUEST) -> REQUEST_RESULT,
 
-  /// a.k.a Release()
-  pub RequestUnUse: extern "system" fn (rq: HREQUEST) -> REQUEST_RESULT,
+	/// a.k.a Release()
+	pub RequestUnUse: extern "system" fn(rq: HREQUEST) -> REQUEST_RESULT,
 
-  /// get requested URL
-  pub RequestUrl: extern "system" fn (rq: HREQUEST, rcv: LPCSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
+	/// get requested URL
+	pub RequestUrl: extern "system" fn(rq: HREQUEST, rcv: LPCSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
 
-  /// get real, content URL (after possible redirection)
-  pub RequestContentUrl: extern "system" fn (rq: HREQUEST, rcv: LPCSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
+	/// get real, content URL (after possible redirection)
+	pub RequestContentUrl: extern "system" fn(rq: HREQUEST, rcv: LPCSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
 
-  /// get requested data type
-  pub RequestGetRequestType: extern "system" fn (rq: HREQUEST, pType: &mut REQUEST_METHOD) -> REQUEST_RESULT,
+	/// get requested data type
+	pub RequestGetRequestType: extern "system" fn(rq: HREQUEST, pType: &mut REQUEST_METHOD) -> REQUEST_RESULT,
 
-  /// get requested data type
-  pub RequestGetRequestedDataType: extern "system" fn (rq: HREQUEST, pData: &mut RESOURCE_TYPE) -> REQUEST_RESULT,
+	/// get requested data type
+	pub RequestGetRequestedDataType: extern "system" fn(rq: HREQUEST, pData: &mut RESOURCE_TYPE) -> REQUEST_RESULT,
 
-  /// get received data type, string, mime type
-  pub RequestGetReceivedDataType: extern "system" fn (rq: HREQUEST, rcv: LPCSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
+	/// get received data type, string, mime type
+	pub RequestGetReceivedDataType: extern "system" fn(rq: HREQUEST, rcv: LPCSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
 
+	/// get number of request parameters passed
+	pub RequestGetNumberOfParameters: extern "system" fn(rq: HREQUEST, pNumber: &mut UINT) -> REQUEST_RESULT,
 
-  /// get number of request parameters passed
-  pub RequestGetNumberOfParameters: extern "system" fn (rq: HREQUEST, pNumber: &mut UINT) -> REQUEST_RESULT,
+	/// get nth request parameter name
+	pub RequestGetNthParameterName: extern "system" fn(rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
 
-  /// get nth request parameter name
-  pub RequestGetNthParameterName: extern "system" fn (rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
+	/// get nth request parameter value
+	pub RequestGetNthParameterValue: extern "system" fn(rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
 
-  /// get nth request parameter value
-  pub RequestGetNthParameterValue: extern "system" fn (rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
+	/// get request times , ended - started = milliseconds to get the requst
+	pub RequestGetTimes: extern "system" fn(rq: HREQUEST, pStarted: &mut UINT, pEnded: &mut UINT) -> REQUEST_RESULT,
 
-  /// get request times , ended - started = milliseconds to get the requst
-  pub RequestGetTimes: extern "system" fn (rq: HREQUEST, pStarted: &mut UINT, pEnded: &mut UINT) -> REQUEST_RESULT,
+	/// get number of request headers
+	pub RequestGetNumberOfRqHeaders: extern "system" fn(rq: HREQUEST, pNumber: &mut UINT) -> REQUEST_RESULT,
 
-  /// get number of request headers
-  pub RequestGetNumberOfRqHeaders: extern "system" fn (rq: HREQUEST, pNumber: &mut UINT) -> REQUEST_RESULT,
+	/// get nth request header name
+	pub RequestGetNthRqHeaderName: extern "system" fn(rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
 
-  /// get nth request header name
-  pub RequestGetNthRqHeaderName: extern "system" fn (rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
+	/// get nth request header value
+	pub RequestGetNthRqHeaderValue: extern "system" fn(rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
 
-  /// get nth request header value
-  pub RequestGetNthRqHeaderValue: extern "system" fn (rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
+	/// get number of response headers
+	pub RequestGetNumberOfRspHeaders: extern "system" fn(rq: HREQUEST, pNumber: &mut UINT) -> REQUEST_RESULT,
 
-  /// get number of response headers
-  pub RequestGetNumberOfRspHeaders: extern "system" fn (rq: HREQUEST, pNumber: &mut UINT) -> REQUEST_RESULT,
+	/// get nth response header name
+	pub RequestGetNthRspHeaderName: extern "system" fn(rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
 
-  /// get nth response header name
-  pub RequestGetNthRspHeaderName: extern "system" fn (rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
+	/// get nth response header value
+	pub RequestGetNthRspHeaderValue: extern "system" fn(rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
 
-  /// get nth response header value
-  pub RequestGetNthRspHeaderValue: extern "system" fn (rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
+	/// get completion status (CompletionStatus - http response code : 200, 404, etc.)
+	pub RequestGetCompletionStatus:
+		extern "system" fn(rq: HREQUEST, pState: &mut REQUEST_STATE, pCompletionStatus: &mut UINT) -> REQUEST_RESULT,
 
-  /// get completion status (CompletionStatus - http response code : 200, 404, etc.)
-  pub RequestGetCompletionStatus: extern "system" fn (rq: HREQUEST, pState: &mut REQUEST_STATE, pCompletionStatus: &mut UINT) -> REQUEST_RESULT,
+	/// get proxy host
+	pub RequestGetProxyHost: extern "system" fn(rq: HREQUEST, rcv: LPCSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
 
-  /// get proxy host
-  pub RequestGetProxyHost: extern "system" fn (rq: HREQUEST, rcv: LPCSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
+	/// get proxy port
+	pub RequestGetProxyPort: extern "system" fn(rq: HREQUEST, pPort: &mut UINT) -> REQUEST_RESULT,
 
-  /// get proxy port
-  pub RequestGetProxyPort: extern "system" fn (rq: HREQUEST, pPort: &mut UINT) -> REQUEST_RESULT,
+	/// mark reequest as complete with status and data
+	pub RequestSetSucceeded: extern "system" fn(rq: HREQUEST, status: UINT, dataOrNull: LPCBYTE, dataLength: UINT) -> REQUEST_RESULT,
 
-  /// mark reequest as complete with status and data
-  pub RequestSetSucceeded: extern "system" fn (rq: HREQUEST, status: UINT, dataOrNull: LPCBYTE, dataLength: UINT) -> REQUEST_RESULT,
+	/// mark reequest as complete with failure and optional data
+	pub RequestSetFailed: extern "system" fn(rq: HREQUEST, status: UINT, dataOrNull: LPCBYTE, dataLength: UINT) -> REQUEST_RESULT,
 
-  /// mark reequest as complete with failure and optional data
-  pub RequestSetFailed: extern "system" fn (rq: HREQUEST, status: UINT, dataOrNull: LPCBYTE, dataLength: UINT) -> REQUEST_RESULT,
+	/// append received data chunk
+	pub RequestAppendDataChunk: extern "system" fn(rq: HREQUEST, data: LPCBYTE, dataLength: UINT) -> REQUEST_RESULT,
 
-  /// append received data chunk
-  pub RequestAppendDataChunk: extern "system" fn (rq: HREQUEST, data: LPCBYTE, dataLength: UINT) -> REQUEST_RESULT,
+	/// set request header (single item)
+	pub RequestSetRqHeader: extern "system" fn(rq: HREQUEST, name: LPCWSTR, value: LPCWSTR) -> REQUEST_RESULT,
 
-  /// set request header (single item)
-  pub RequestSetRqHeader: extern "system" fn (rq: HREQUEST, name: LPCWSTR, value: LPCWSTR) -> REQUEST_RESULT,
+	/// set respone header (single item)
+	pub RequestSetRspHeader: extern "system" fn(rq: HREQUEST, name: LPCWSTR, value: LPCWSTR) -> REQUEST_RESULT,
 
-  /// set respone header (single item)
-  pub RequestSetRspHeader: extern "system" fn (rq: HREQUEST, name: LPCWSTR, value: LPCWSTR) -> REQUEST_RESULT,
+	/// set received data type, string, mime type
+	pub RequestSetReceivedDataType: extern "system" fn(rq: HREQUEST, _type: LPCSTR) -> REQUEST_RESULT,
 
-  /// set received data type, string, mime type
-  pub RequestSetReceivedDataType: extern "system" fn (rq: HREQUEST, _type: LPCSTR) -> REQUEST_RESULT,
+	/// set received data encoding, string
+	pub RequestSetReceivedDataEncoding: extern "system" fn(rq: HREQUEST, encoding: LPCSTR) -> REQUEST_RESULT,
 
-  /// set received data encoding, string
-  pub RequestSetReceivedDataEncoding: extern "system" fn (rq: HREQUEST, encoding: LPCSTR) -> REQUEST_RESULT,
-
-  /// get received (so far) data
-  pub RequestGetData: extern "system" fn (rq: HREQUEST, rcv: LPCBYTE_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
+	/// get received (so far) data
+	pub RequestGetData: extern "system" fn(rq: HREQUEST, rcv: LPCBYTE_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT,
 }

--- a/src/capi/sctiscript.rs
+++ b/src/capi/sctiscript.rs
@@ -2,7 +2,7 @@
 
 #![allow(non_camel_case_types, non_snake_case)]
 
-use capi::sctypes::{LPVOID, UINT64};
+use crate::capi::sctypes::{LPVOID, UINT64};
 
 MAKE_HANDLE!(#[doc = "TIScript VM native handle."] HVM, _HVM);
 

--- a/src/capi/scvalue.rs
+++ b/src/capi/scvalue.rs
@@ -3,15 +3,14 @@
 #![allow(non_snake_case, non_camel_case_types)]
 #![allow(dead_code)]
 
-use capi::sctypes::*;
+use crate::capi::sctypes::*;
 
 /// A JSON value.
 ///
 /// An opaque union that can hold different types of values: numbers, strings, arrays, objects, etc.
 #[repr(C)]
 #[derive(Default, Debug, Clone)]
-pub struct VALUE
-{
+pub struct VALUE {
 	/// Value type.
 	pub t: VALUE_TYPE,
 
@@ -35,12 +34,11 @@ impl VALUE {
 
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
-pub enum VALUE_RESULT
-{
-  OK_TRUE = -1,
-  OK = 0,
-  BAD_PARAMETER = 1,
-  INCOMPATIBLE_TYPE = 2,
+pub enum VALUE_RESULT {
+	OK_TRUE = -1,
+	OK = 0,
+	BAD_PARAMETER = 1,
+	INCOMPATIBLE_TYPE = 2,
 }
 
 impl std::error::Error for VALUE_RESULT {}
@@ -51,7 +49,6 @@ impl std::fmt::Display for VALUE_RESULT {
 	}
 }
 
-
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
 pub enum VALUE_STRING_CVT_TYPE {
@@ -60,7 +57,6 @@ pub enum VALUE_STRING_CVT_TYPE {
 	JSON_MAP = 2,
 	XJSON_LITERAL = 3,
 }
-
 
 /// Type identifier of the value.
 #[repr(C)]
@@ -116,16 +112,15 @@ pub enum VALUE_TYPE {
 }
 
 impl Default for VALUE_TYPE {
-    fn default() -> Self {
-        Self::T_UNDEFINED
-    }
+	fn default() -> Self {
+		Self::T_UNDEFINED
+	}
 }
 
 /// `undefined` sub-state.
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
-pub enum VALUE_UNIT_UNDEFINED
-{
+pub enum VALUE_UNIT_UNDEFINED {
 	/// 'nothing' a.k.a. 'void' value in script.
 	UT_NOTHING = 1,
 }
@@ -133,41 +128,38 @@ pub enum VALUE_UNIT_UNDEFINED
 /// String sub-types.
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
-pub enum VALUE_UNIT_TYPE_STRING
-{
-	STRING = 0,        // string
-	ERROR  = 1,        // is an error string
-	SECURE = 2,        // secure string ("wiped" on destroy)
-	URL 	 = 3,				 // url(...)
-	SELECTOR = 4,			 // selector(...)
-	FILE = 0xfffe,     // file name
-	SYMBOL = 0xffff,   // symbol in tiscript sense
+pub enum VALUE_UNIT_TYPE_STRING {
+	STRING = 0,      // string
+	ERROR = 1,       // is an error string
+	SECURE = 2,      // secure string ("wiped" on destroy)
+	URL = 3,         // url(...)
+	SELECTOR = 4,    // selector(...)
+	FILE = 0xfffe,   // file name
+	SYMBOL = 0xffff, // symbol in tiscript sense
 }
 
 /// Length sub-types.
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
-pub enum VALUE_UNIT_TYPE_LENGTH
-{
-	EM = 1, //height of the element's font.
-	EX = 2, //height of letter 'x'
-	PR = 3, //%
-	SP = 4, //%% "springs", a.k.a. flex units
-	PX = 7, //pixels
-	IN = 8, //inches (1 inch = 2.54 centimeters).
-	CM = 9, //centimeters.
+pub enum VALUE_UNIT_TYPE_LENGTH {
+	EM = 1,  //height of the element's font.
+	EX = 2,  //height of letter 'x'
+	PR = 3,  //%
+	SP = 4,  //%% "springs", a.k.a. flex units
+	PX = 7,  //pixels
+	IN = 8,  //inches (1 inch = 2.54 centimeters).
+	CM = 9,  //centimeters.
 	MM = 10, //millimeters.
 	PT = 11, //points (1 point = 1/72 inches).
 	PC = 12, //picas (1 pica = 12 points).
 	DIP = 13,
-	URL   = 16,  // url in string
+	URL = 16, // url in string
 }
 
 /// Array sub-types.
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
-pub enum VALUE_UNIT_TYPE_ARRAY
-{
+pub enum VALUE_UNIT_TYPE_ARRAY {
 	/// White space separated list.
 	WT_LIST = 1,
 	/// Comma separated list.
@@ -179,15 +171,14 @@ pub enum VALUE_UNIT_TYPE_ARRAY
 // Sciter or TIScript specific
 #[repr(C)]
 #[derive(Debug, PartialOrd, PartialEq)]
-pub enum VALUE_UNIT_TYPE_OBJECT
-{
-	ARRAY  = 0,   // type T_OBJECT of type Array
+pub enum VALUE_UNIT_TYPE_OBJECT {
+	ARRAY = 0,    // type T_OBJECT of type Array
 	OBJECT = 1,   // type T_OBJECT of type Object
-	CLASS  = 2,   // type T_OBJECT of type Class (class or namespace)
+	CLASS = 2,    // type T_OBJECT of type Class (class or namespace)
 	NATIVE = 3,   // type T_OBJECT of native Type with data slot (LPVOID)
 	FUNCTION = 4, // type T_OBJECT of type Function
 	ERROR = 5,    // type T_OBJECT of type Error
 }
 
-pub type NATIVE_FUNCTOR_INVOKE = extern "C" fn (tag: LPVOID, argc: UINT, argv: *const VALUE, retval: * mut VALUE);
-pub type NATIVE_FUNCTOR_RELEASE = extern "C" fn (tag: LPVOID);
+pub type NATIVE_FUNCTOR_INVOKE = extern "C" fn(tag: LPVOID, argc: UINT, argv: *const VALUE, retval: *mut VALUE);
+pub type NATIVE_FUNCTOR_RELEASE = extern "C" fn(tag: LPVOID);

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -58,8 +58,8 @@ You can change the **text** or **html** of a DOM element:
 ```rust,no_run
 # let root = sciter::dom::Element::from(::std::ptr::null_mut());
 if let Some(mut el) = root.find_first("#cancel").unwrap() {
-  el.set_text("Abort!");
-  el.set_html(br##"<img src="http://lorempixel.com/32/32/cats/" alt="some cat"/>"##, None);
+	el.set_text("Abort!");
+	el.set_html(br##"<img src="http://lorempixel.com/32/32/cats/" alt="some cat"/>"##, None);
 }
 ```
 
@@ -142,8 +142,8 @@ Here is how to set a numeric value of a DOM element in native code:
 # use sciter::Value;
 # let root = sciter::dom::Element::from(::std::ptr::null_mut());
 if let Some(mut num) = root.find_first("input[type=number]").unwrap() {
-  num.set_value( Value::from(12) );  // sciter::Value with T_INT type (i32 in Rust)
-  num.set_value(12);  // equivalent but with implicit conversion
+	num.set_value( Value::from(12) );  // sciter::Value with T_INT type (i32 in Rust)
+	num.set_value(12);  // equivalent but with implicit conversion
 }
 ```
 
@@ -151,43 +151,43 @@ In script the same will look like:
 
 ```tiscript
 if (var num = self.select("input[type=number]")) {
-  num.value = 12;
+	num.value = 12;
 }
 ```
 
 .
 */
 
-use ::{_API};
-use capi::sctypes::*;
-use value::Value;
+pub use crate::{
+	capi::{
+		scbehavior::{BEHAVIOR_EVENT_PARAMS, BEHAVIOR_EVENTS, CLICK_REASON},
+		scdef::RESOURCE_TYPE,
+		scdom::{ELEMENT_AREAS, ELEMENT_STATE_BITS, HELEMENT, SCDOM_RESULT, SET_ELEMENT_HTML},
+		screquest::{REQUEST_PARAM, REQUEST_TYPE},
+		sctypes::*,
+	},
+	dom::event::{EventHandler, EventReason},
+	value::Value,
+};
 
-use capi::screquest::{REQUEST_PARAM, REQUEST_TYPE};
-use capi::scdef::RESOURCE_TYPE;
-use capi::scbehavior::{CLICK_REASON, BEHAVIOR_EVENTS, BEHAVIOR_EVENT_PARAMS};
-use utf::{store_astr, store_wstr, store_bstr};
-
-pub use capi::scdom::{SCDOM_RESULT, HELEMENT, SET_ELEMENT_HTML, ELEMENT_AREAS, ELEMENT_STATE_BITS};
-pub use dom::event::{EventHandler, EventReason};
-
+use crate::{
+	_API,
+	utf::{store_astr, store_bstr, store_wstr},
+};
 
 /// A specialized `Result` type for DOM operations.
 pub type Result<T> = ::std::result::Result<T, SCDOM_RESULT>;
 
-
 /// Initialize HELEMENT by nullptr.
 macro_rules! HELEMENT {
-	() => { ::std::ptr::null_mut() }
+	() => {
+		::std::ptr::null_mut()
+	};
 }
-
 
 macro_rules! ok_or {
 	($rv:expr, $ok:ident) => {
-		if $ok == SCDOM_RESULT::OK {
-			Ok($rv)
-		} else {
-			Err($ok)
-		}
+		if $ok == SCDOM_RESULT::OK { Ok($rv) } else { Err($ok) }
 	};
 
 	// for DOM access not_handled is ok
@@ -200,7 +200,6 @@ macro_rules! ok_or {
 		}
 	};
 }
-
 
 trait ElementVisitor {
 	fn on_element(&mut self, el: Element) -> bool;
@@ -215,7 +214,7 @@ struct FindFirstElement {
 impl ElementVisitor for FindFirstElement {
 	fn on_element(&mut self, el: Element) -> bool {
 		self.all.push(el);
-		return true;	// stop enumeration
+		return true; // stop enumeration
 	}
 	fn result(&self) -> Vec<Element> {
 		self.all.clone()
@@ -230,13 +229,12 @@ struct FindAllElements {
 impl ElementVisitor for FindAllElements {
 	fn on_element(&mut self, el: Element) -> bool {
 		self.all.push(el);
-		return false;	// continue enumeration
+		return false; // continue enumeration
 	}
 	fn result(&self) -> Vec<Element> {
 		self.all.clone()
 	}
 }
-
 
 /// DOM element wrapper. See the module-level documentation also.
 #[derive(PartialEq)]
@@ -281,11 +279,7 @@ impl crate::value::FromValue for Element {
 		if crate::api_version() >= DOM_UNWRAP_API_VERSION {
 			let mut h = std::ptr::null_mut();
 			let ok = (_API.SciterElementUnwrap)(v.as_cptr(), &mut h);
-			if ok == SCDOM_RESULT::OK {
-				Some(Element::from(h))
-			} else {
-				None
-			}
+			if ok == SCDOM_RESULT::OK { Some(Element::from(h)) } else { None }
 		} else {
 			let mut pv: LPCBYTE = std::ptr::null();
 			let mut cb: UINT = 0;
@@ -300,7 +294,6 @@ impl crate::value::FromValue for Element {
 }
 
 impl Element {
-
 	//\name Creation
 
 	/// Create a new element, it is disconnected initially from the DOM.
@@ -323,7 +316,7 @@ impl Element {
 	}
 
 	/// Create new element as child of `parent`. Deprecated.
-	#[deprecated(since="0.5.0", note="please use `Element::with_parent()` instead.")]
+	#[deprecated(since = "0.5.0", note = "please use `Element::with_parent()` instead.")]
 	pub fn create_at(tag: &str, parent: &mut Element) -> Result<Element> {
 		Element::with_parent(tag, parent)
 	}
@@ -361,11 +354,7 @@ impl Element {
 	///
 	/// https://github.com/sciter-sdk/rust-sciter/issues/27
 	fn forbid_null(e: Element) -> Result<Element> {
-		if e.he.is_null() {
-			Err(SCDOM_RESULT::OK_NOT_HANDLED)
-		} else {
-			Ok(e)
-		}
+		if e.he.is_null() { Err(SCDOM_RESULT::OK_NOT_HANDLED) } else { Ok(e) }
 	}
 
 	/// Get the root DOM element of the Sciter document.
@@ -416,13 +405,8 @@ impl Element {
 	#[doc(hidden)]
 	fn use_or(he: HELEMENT) -> HELEMENT {
 		let ok = (_API.Sciter_UseElement)(he);
-		if ok == SCDOM_RESULT::OK {
-			he
-		} else {
-			HELEMENT!()
-		}
+		if ok == SCDOM_RESULT::OK { he } else { HELEMENT!() }
 	}
-
 
 	//\name Common methods
 
@@ -454,7 +438,7 @@ impl Element {
 
 	/// Set inner text of the element.
 	pub fn set_text(&mut self, text: &str) -> Result<()> {
-		let (s,n) = s2wn!(text);
+		let (s, n) = s2wn!(text);
 		let ok = (_API.SciterSetElementText)(self.he, s.as_ptr(), n);
 		ok_or!((), ok)
 	}
@@ -471,7 +455,12 @@ impl Element {
 		if html.is_empty() {
 			return self.clear();
 		}
-		let ok = (_API.SciterSetElementHtml)(self.he, html.as_ptr(), html.len() as UINT, how.unwrap_or(SET_ELEMENT_HTML::SIH_REPLACE_CONTENT) as UINT);
+		let ok = (_API.SciterSetElementHtml)(
+			self.he,
+			html.as_ptr(),
+			html.len() as UINT,
+			how.unwrap_or(SET_ELEMENT_HTML::SIH_REPLACE_CONTENT) as UINT,
+		);
 		ok_or!((), ok)
 	}
 
@@ -547,7 +536,14 @@ impl Element {
 	pub fn send_get_request(&self, url: &str) -> Result<()> {
 		let url = s2w!(url);
 		let no_params = ::std::ptr::null();
-		let ok = (_API.SciterHttpRequest)(self.he, url.as_ptr(), RESOURCE_TYPE::HTML as u32, REQUEST_TYPE::AsyncGet as u32, no_params, 0);
+		let ok = (_API.SciterHttpRequest)(
+			self.he,
+			url.as_ptr(),
+			RESOURCE_TYPE::HTML as u32,
+			REQUEST_TYPE::AsyncGet as u32,
+			no_params,
+			0,
+		);
 		ok_or!((), ok)
 	}
 
@@ -555,8 +551,13 @@ impl Element {
 	///
 	/// GET params (if any) are appended to the url to form the request.<br/>
 	/// HTTP POST params are serialized as `Content-Type: application/x-www-form-urlencoded;charset=utf-8;`.
-	pub fn send_request(&self, url: &str, params: Option<&[(&str, &str)]>, method: Option<REQUEST_TYPE>, data_type: Option<RESOURCE_TYPE>) -> Result<()> {
-
+	pub fn send_request(
+		&self,
+		url: &str,
+		params: Option<&[(&str, &str)]>,
+		method: Option<REQUEST_TYPE>,
+		data_type: Option<RESOURCE_TYPE>,
+	) -> Result<()> {
 		let url = s2w!(url);
 		let method = method.unwrap_or(REQUEST_TYPE::AsyncGet) as u32;
 		let data_type = data_type.unwrap_or(RESOURCE_TYPE::HTML) as u32;
@@ -572,9 +573,9 @@ impl Element {
 			wide_params.reserve_exact(count);
 			call_params.reserve_exact(count);
 
-			for (k,v) in params {
+			for (k, v) in params {
 				let (kw, vw) = (s2w!(k), s2w!(v));
-				call_params.push (REQUEST_PARAM {
+				call_params.push(REQUEST_PARAM {
 					name: kw.as_ptr(),
 					value: vw.as_ptr(),
 				});
@@ -582,7 +583,14 @@ impl Element {
 			}
 		}
 
-		let ok = (_API.SciterHttpRequest)(self.he, url.as_ptr(), data_type, method, call_params.as_ptr(), call_params.len() as u32);
+		let ok = (_API.SciterHttpRequest)(
+			self.he,
+			url.as_ptr(),
+			data_type,
+			method,
+			call_params.as_ptr(),
+			call_params.len() as u32,
+		);
 		ok_or!((), ok)
 	}
 
@@ -604,7 +612,14 @@ impl Element {
 	}
 
 	/// Send or posts event to the child/parent chain of the element.
-	pub fn fire_event(&self, code: BEHAVIOR_EVENTS, reason: Option<CLICK_REASON>, source: Option<HELEMENT>, post: bool, data: Option<Value>) -> Result<bool> {
+	pub fn fire_event(
+		&self,
+		code: BEHAVIOR_EVENTS,
+		reason: Option<CLICK_REASON>,
+		source: Option<HELEMENT>,
+		post: bool,
+		data: Option<Value>,
+	) -> Result<bool> {
 		let mut handled = false as BOOL;
 		let mut params = BEHAVIOR_EVENT_PARAMS {
 			cmd: code as UINT,
@@ -631,7 +646,7 @@ impl Element {
 	/// Broadcast a custom named event to all windows.
 	pub fn broadcast_event(&self, name: &str, post: bool, data: Option<Value>) -> Result<bool> {
 		let name = s2w!(name);
-		let mut  params = BEHAVIOR_EVENT_PARAMS {
+		let mut params = BEHAVIOR_EVENT_PARAMS {
 			cmd: BEHAVIOR_EVENTS::CUSTOM as UINT,
 			heTarget: HELEMENT!(),
 			reason: 0,
@@ -647,11 +662,10 @@ impl Element {
 		ok_or!(handled != 0, ok)
 	}
 
-
 	/// Evaluate the given script in context of the element.
 	pub fn eval_script(&self, script: &str) -> Result<Value> {
 		let mut rv = Value::new();
-		let (s,n) = s2wn!(script);
+		let (s, n) = s2wn!(script);
 		let ok = (_API.SciterEvalElementScript)(self.he, s.as_ptr(), n, rv.as_ptr());
 		return ok_or!(rv, ok, SCDOM_RESULT::OPERATION_FAILED);
 	}
@@ -680,61 +694,56 @@ impl Element {
 		return ok_or!(rv, ok, SCDOM_RESULT::OPERATION_FAILED);
 	}
 
-  /// Call behavior specific method.
-  pub fn call_behavior_method(&self, params: event::MethodParams) -> Result<()> {
-    let call = |p| {
-      (_API.SciterCallBehaviorMethod)(self.he, p)
-    };
-    use capi::scbehavior::{METHOD_PARAMS, VALUE_PARAMS, IS_EMPTY_PARAMS};
-    use capi::scbehavior::BEHAVIOR_METHOD_IDENTIFIERS::*;
-    let ok = match params {
-      event::MethodParams::Click => {
-        let mut p = METHOD_PARAMS {
-          method: DO_CLICK as u32,
-        };
-        call(&mut p as *mut _)
-      },
-      event::MethodParams::SetValue(v) => {
-        let mut p = VALUE_PARAMS {
-          method: SET_VALUE as u32,
-          value: Default::default(),
-        };
-        v.pack_to(&mut p.value);
-        call(&mut p as *mut _ as *mut METHOD_PARAMS)
-      },
-      event::MethodParams::GetValue(retv) => {
-        let mut p = VALUE_PARAMS {
-          method: SET_VALUE as u32,
-          value: Default::default(),
-        };
-        let ok = call(&mut p as *mut _ as *mut METHOD_PARAMS);
-        if ok != SCDOM_RESULT::OK {
-          return Err(ok);
-        }
-        *retv = Value::from(&p.value);
-        ok
-      },
-      event::MethodParams::IsEmpty(retv) => {
-        let mut p = IS_EMPTY_PARAMS {
-          method: IS_EMPTY as u32,
-          is_empty: Default::default(),
-        };
-        let ok = call(&mut p as *mut _ as *mut METHOD_PARAMS);
-        if ok != SCDOM_RESULT::OK {
-          return Err(ok);
-        }
-        *retv = p.is_empty != 0;
-        ok
-      },
+	/// Call behavior specific method.
+	pub fn call_behavior_method(&self, params: event::MethodParams) -> Result<()> {
+		let call = |p| (_API.SciterCallBehaviorMethod)(self.he, p);
+		use crate::capi::scbehavior::BEHAVIOR_METHOD_IDENTIFIERS::*;
+		use crate::capi::scbehavior::{IS_EMPTY_PARAMS, METHOD_PARAMS, VALUE_PARAMS};
+		let ok = match params {
+			event::MethodParams::Click => {
+				let mut p = METHOD_PARAMS { method: DO_CLICK as u32 };
+				call(&mut p as *mut _)
+			}
+			event::MethodParams::SetValue(v) => {
+				let mut p = VALUE_PARAMS {
+					method: SET_VALUE as u32,
+					value: Default::default(),
+				};
+				v.pack_to(&mut p.value);
+				call(&mut p as *mut _ as *mut METHOD_PARAMS)
+			}
+			event::MethodParams::GetValue(retv) => {
+				let mut p = VALUE_PARAMS {
+					method: SET_VALUE as u32,
+					value: Default::default(),
+				};
+				let ok = call(&mut p as *mut _ as *mut METHOD_PARAMS);
+				if ok != SCDOM_RESULT::OK {
+					return Err(ok);
+				}
+				*retv = Value::from(&p.value);
+				ok
+			}
+			event::MethodParams::IsEmpty(retv) => {
+				let mut p = IS_EMPTY_PARAMS {
+					method: IS_EMPTY as u32,
+					is_empty: Default::default(),
+				};
+				let ok = call(&mut p as *mut _ as *mut METHOD_PARAMS);
+				if ok != SCDOM_RESULT::OK {
+					return Err(ok);
+				}
+				*retv = p.is_empty != 0;
+				ok
+			}
 
-      _ => {
-        // Can't handle `MethodParams::Custom` yet.
-        SCDOM_RESULT::INVALID_PARAMETER
-      },
-    };
-    ok_or!((), ok)
-  }
-
+			_ => {
+				// Can't handle `MethodParams::Custom` yet.
+				SCDOM_RESULT::INVALID_PARAMETER
+			}
+		};
+		ok_or!((), ok)
+	}
 
 	//\name Attributes
 	/// Get number of the attributes.
@@ -801,7 +810,6 @@ impl Element {
 		ok_or!((), ok)
 	}
 
-
 	//\name Style Attributes
 
 	/// Get [style attribute](https://sciter.com/docs/content/sciter/Style.htm) of the element by its name.
@@ -822,7 +830,6 @@ impl Element {
 
 	//\name State methods
 
-
 	//\name DOM tree access
 
 	/// Get index of this element in its parent collection.
@@ -834,22 +841,14 @@ impl Element {
 
 	/// Get root of the element.
 	pub fn root(&self) -> Element {
-		if let Some(dad) = self.parent() {
-			dad.root()
-		} else {
-			self.clone()
-		}
+		if let Some(dad) = self.parent() { dad.root() } else { self.clone() }
 	}
 
 	/// Get parent element.
 	pub fn parent(&self) -> Option<Element> {
 		let mut p = HELEMENT!();
 		(_API.SciterGetParentElement)(self.he, &mut p);
-		if p.is_null() {
-			None
-		} else {
-			Some(Element::from(p))
-		}
+		if p.is_null() { None } else { Some(Element::from(p)) }
 	}
 
 	/// Get first sibling element.
@@ -918,7 +917,7 @@ impl Element {
 	}
 
 	/// An iterator over the direct children of a DOM element.
-	pub fn children(&self) -> Children {
+	pub fn children(&self) -> Children<'_> {
 		Children {
 			base: self,
 			index: 0,
@@ -932,7 +931,7 @@ impl Element {
 		let ok = (_API.SciterGetNthChild)(self.he, index as UINT, &mut p);
 		match ok {
 			SCDOM_RESULT::OK => Some(Element::from(p)),
-			_ => None
+			_ => None,
 		}
 	}
 
@@ -1035,7 +1034,7 @@ impl Element {
 	/// Call specified function for every element in a DOM that meets specified CSS selectors.
 	fn select_elements<T: ElementVisitor>(&self, selector: &str, callback: T) -> Result<Vec<Element>> {
 		extern "system" fn inner<T: ElementVisitor>(he: HELEMENT, param: LPVOID) -> BOOL {
-      let p = param as *mut T;
+			let p = param as *mut T;
 			let obj = unsafe { &mut *p };
 			let e = Element::from(he);
 			let stop = obj.on_element(e);
@@ -1043,9 +1042,9 @@ impl Element {
 		}
 		let s = s2u!(selector);
 		let handler = Box::new(callback);
-    let param = Box::into_raw(handler);
+		let param = Box::into_raw(handler);
 		let ok = (_API.SciterSelectElements)(self.he, s.as_ptr(), inner::<T>, param as LPVOID);
-    let handler = unsafe { Box::from_raw(param) };
+		let handler = unsafe { Box::from_raw(param) };
 		if ok != SCDOM_RESULT::OK {
 			return Err(ok);
 		}
@@ -1067,7 +1066,7 @@ impl Element {
 	pub fn find_first(&self, selector: &str) -> Result<Option<Element>> {
 		let cb = FindFirstElement::default();
 		let all = self.select_elements(selector, cb);
-		all.map(|mut x| { x.pop() })
+		all.map(|mut x| x.pop())
 	}
 
 	/// Will find all elements starting from this satisfying given css selector(s).
@@ -1102,14 +1101,14 @@ impl Element {
 	///
 	/// Note that timer events are not bubbling, so you need attach handler to the target element directly.
 	pub fn start_timer(&self, period_ms: u32, timer_id: u64) -> Result<()> {
-		let ok = (_API.SciterSetTimer)(self.he, period_ms as UINT, timer_id as ::capi::sctypes::UINT_PTR);
+		let ok = (_API.SciterSetTimer)(self.he, period_ms as UINT, timer_id as crate::capi::sctypes::UINT_PTR);
 		ok_or!((), ok)
 	}
 
 	/// Stop Timer for the element.
 	pub fn stop_timer(&self, timer_id: u64) -> Result<()> {
 		if !self.he.is_null() {
-			let ok = (_API.SciterSetTimer)(self.he, 0, timer_id as ::capi::sctypes::UINT_PTR);
+			let ok = (_API.SciterSetTimer)(self.he, 0, timer_id as crate::capi::sctypes::UINT_PTR);
 			ok_or!((), ok)
 		} else {
 			Ok(())
@@ -1120,16 +1119,16 @@ impl Element {
 	pub fn attach_handler<Handler: EventHandler>(&mut self, handler: Handler) -> Result<u64> {
 		// make native handler
 		let boxed = Box::new(handler);
-		let ptr = Box::into_raw(boxed);	// dropped in `_event_handler_proc`
+		let ptr = Box::into_raw(boxed); // dropped in `_event_handler_proc`
 		let token = ptr as usize as u64;
-		let ok = (_API.SciterAttachEventHandler)(self.he, ::eventhandler::_event_handler_proc::<Handler>, ptr as LPVOID);
+		let ok = (_API.SciterAttachEventHandler)(self.he, crate::eventhandler::_event_handler_proc::<Handler>, ptr as LPVOID);
 		ok_or!(token, ok)
 	}
 
 	/// Detach your handler from the element. Handlers identified by `token` from `attach_handler()` result.
 	pub fn detach_handler<Handler: EventHandler>(&mut self, token: u64) -> Result<()> {
 		let ptr = token as usize as *mut Handler;
-		let ok = (_API.SciterDetachEventHandler)(self.he, ::eventhandler::_event_handler_proc::<Handler>, ptr as LPVOID);
+		let ok = (_API.SciterDetachEventHandler)(self.he, crate::eventhandler::_event_handler_proc::<Handler>, ptr as LPVOID);
 		ok_or!((), ok)
 	}
 }
@@ -1158,19 +1157,19 @@ impl ::std::fmt::Display for Element {
 		// "tag#id.class|type(name)"
 		// "tag#id.class"
 
-    let tag = self.get_tag();
+		let tag = self.get_tag();
 		f.write_str(&tag)?;
 
 		if let Some(i) = self.get_attribute("id") {
 			write!(f, "#{}", i)?;
 		}
-    if let Some(c) = self.get_attribute("class") {
+		if let Some(c) = self.get_attribute("class") {
 			write!(f, ".{}", c)?;
 		}
-    if let Some(t) = self.get_attribute("type") {
+		if let Some(t) = self.get_attribute("type") {
 			write!(f, "|{}", t)?;
 		}
-    if let Some(n) = self.get_attribute("name") {
+		if let Some(n) = self.get_attribute("name") {
 			write!(f, "({})", n)?;
 		}
 		return Ok(());
@@ -1237,14 +1236,12 @@ impl ::std::fmt::Debug for Element {
 				}
 			}
 			write!(f, "}}")
-
 		} else {
 			// "tag#id.class(name):0xdfdfdf"
 			write!(f, "{{{}:{:?}}}", self, self.he)
 		}
 	}
 }
-
 
 /// An iterator over the direct children of a DOM element.
 pub struct Children<'a> {
@@ -1297,7 +1294,6 @@ impl<'a> ::std::iter::IntoIterator for &'a Element {
 		self.children()
 	}
 }
-
 
 /* Not implemented yet or not used APIs:
 
@@ -1354,131 +1350,134 @@ pub mod event {
 	//!
 	/*!
 
-# Behaviors and event handling.
+	# Behaviors and event handling.
 
-The primary goal of the User Interface (UI) as a subsystem is to present some information to the user
-and generate some events according to user’s actions.
-Your application handles UI events and acts accordingly executing its functions.
+	The primary goal of the User Interface (UI) as a subsystem is to present some information to the user
+	and generate some events according to user’s actions.
+	Your application handles UI events and acts accordingly executing its functions.
 
-To be able to handle events in native code you will need to attach an instance of
-[`sciter::EventHandler`](trait.EventHandler.html)
-to an existing DOM element or to the window itself.
-In `EventHandler`'s implementation you will receive all events
-dispatched to the element and its children as before children (in [`PHASE_MASK::SINKING`](enum.PHASE_MASK.html) phase)
-as after them ([`PHASE_MASK::BUBBLING`](enum.PHASE_MASK.html) event phase),
-see [Events Propagation](https://sciter.com/developers/for-native-gui-programmers/#events-propagation).
+	To be able to handle events in native code you will need to attach an instance of
+	[`sciter::EventHandler`](trait.EventHandler.html)
+	to an existing DOM element or to the window itself.
+	In `EventHandler`'s implementation you will receive all events
+	dispatched to the element and its children as before children (in [`PHASE_MASK::SINKING`](enum.PHASE_MASK.html) phase)
+	as after them ([`PHASE_MASK::BUBBLING`](enum.PHASE_MASK.html) event phase),
+	see [Events Propagation](https://sciter.com/developers/for-native-gui-programmers/#events-propagation).
 
-`EventHandler` attached to the window will receive all DOM events no matter which element they are targeted to.
+	`EventHandler` attached to the window will receive all DOM events no matter which element they are targeted to.
 
-`EventHandler` contains [various methods](trait.EventHandler.html#provided-methods) –
-receivers of events of various types.
-You can override any of these methods in order to receive events you are interested in
-in your implementation of `sciter::EventHandler`.
-
-
-To attach a native event handler to a DOM element or to the window you can do one of these:
-
-* "Manually", to a Sciter window: `sciter::Window.event_handler(your_event_handler)`
-* "Manually", to an arbitrary DOM element: `sciter::dom::Element.attach_handler(your_event_handler)`
-* To a group of DOM elements by declaration in CSS: `selector { behavior:your-behavior-name }`
-
-You also can assign events handlers defined in script code:
-
-* "Manually", individual events: if you have a reference `el` of some element then
-to handle mouse events you can do this, for example:
-
-```tiscript
-el.onMouse = function(evt) { ... }
-```
-
-* "Manually", by assigning a behavior class to the [Element](https://sciter.com/docs/content/sciter/Element.htm):
-
-```tiscript
-class MyEventsHandler: Element { ... }  // your behavior class which inherits sciter's Element class
-el.prototype = MyEventsHandler; // "sub-class" the element.
-```
-
-* By declaration in CSS - to all elements satisfying some CSS selector:
-
-```css
-selector { prototype: MyEventsHandler; }
-```
-
-In this case `MyEventsHandler` class should be defined in one of script files loaded by your HTML.
-
-See the **Behavior attributes** section of [Sciter CSS property map](https://sciter.com/docs/content/css/cssmap.html)
-and [this blog article](http://www.terrainformatica.com/2014/07/sciter-declarative-behavior-assignment-by-css-prototype-and-aspect-properties/) which covers
-Behaviors, Prototypes and Aspects of Sciter CSS behavior assignment.
+	`EventHandler` contains [various methods](trait.EventHandler.html#provided-methods) –
+	receivers of events of various types.
+	You can override any of these methods in order to receive events you are interested in
+	in your implementation of `sciter::EventHandler`.
 
 
+	To attach a native event handler to a DOM element or to the window you can do one of these:
+
+	* "Manually", to a Sciter window: `sciter::Window.event_handler(your_event_handler)`
+	* "Manually", to an arbitrary DOM element: `sciter::dom::Element.attach_handler(your_event_handler)`
+	* To a group of DOM elements by declaration in CSS: `selector { behavior:your-behavior-name }`
+
+	You also can assign events handlers defined in script code:
+
+	* "Manually", individual events: if you have a reference `el` of some element then
+	to handle mouse events you can do this, for example:
+
+	```tiscript
+	el.onMouse = function(evt) { ... }
+	```
+
+	* "Manually", by assigning a behavior class to the [Element](https://sciter.com/docs/content/sciter/Element.htm):
+
+	```tiscript
+	class MyEventsHandler: Element { ... }  // your behavior class which inherits sciter's Element class
+	el.prototype = MyEventsHandler; // "sub-class" the element.
+	```
+
+	* By declaration in CSS - to all elements satisfying some CSS selector:
+
+	```css
+	selector { prototype: MyEventsHandler; }
+	```
+
+	In this case `MyEventsHandler` class should be defined in one of script files loaded by your HTML.
+
+	See the **Behavior attributes** section of [Sciter CSS property map](https://sciter.com/docs/content/css/cssmap.html)
+	and [this blog article](http://www.terrainformatica.com/2014/07/sciter-declarative-behavior-assignment-by-css-prototype-and-aspect-properties/) which covers
+	Behaviors, Prototypes and Aspects of Sciter CSS behavior assignment.
 
 
 
-# Script and native code interaction
 
 
-In Sciter you may want to define native functions that can be called by script.
-At the same time you may need to call script functions from native code.
-Sciter supports such interaction providing set of simple API functions:
-
-## Evaluating scripts and invoking script functions from native code
-
-You can use one of these methods to call scripts from code of your application:
-
-* To evaluate arbitrary script in context of current document loaded into the window:
-
-```rust,no_run
-# use sciter::dom::Element;
-# use sciter::Value;
-# let hwnd = ::std::ptr::null_mut();
-let root = Element::from_window(hwnd).unwrap();
-let result: Value = root.eval_script("... script ...").unwrap();
-```
-
-* To call a global function defined in script using its full name (may include the name of namespaces where it resides):
-
-```ignore
-# #[macro_use] extern crate sciter;
-# use sciter::Value;
-# let root = sciter::dom::Element::from(::std::ptr::null_mut());
-let result: Value = root.call_function("namespace.name", &make_args!(1, "2", 3.0)).unwrap();
-```
-The parameters are passed as a `&[Value]` slice.
-
-* To call a method (function) defined in script for particular DOM element:
-
-```ignore
-# #[macro_use] extern crate sciter;
-# use sciter::Value;
-# let root = sciter::dom::Element::from(::std::ptr::null_mut());
-if let Some(el) = root.find_first("input").unwrap() {
-  let result: Value = el.call_method("canUndo", &make_args!()).unwrap();
-}
-```
+	# Script and native code interaction
 
 
-## Calling native code from script
+	In Sciter you may want to define native functions that can be called by script.
+	At the same time you may need to call script functions from native code.
+	Sciter supports such interaction providing set of simple API functions:
 
-If needed, your application may expose some [native] functions to be called by script code.
-Usually this is made by implementing your own `EventHandler` and overriding its `on_script_call` method.
-If you do this, then you can invoke this callback from script as:
+	## Evaluating scripts and invoking script functions from native code
 
-* "global" native functions: `var r = view.funcName( p0, p1, ... );` – calling
-`on_script_call` of an `EventHandler` instance attached to the **window**.
-* As element’s methods: `var r = el.funcName( p0, p1, ... );` – calling
-`on_script_call` of an `EventHandler` instance (native behavior) attached to the **element**.
+	You can use one of these methods to call scripts from code of your application:
 
-This way you can establish interaction between scipt and native code inside your application.
+	* To evaluate arbitrary script in context of current document loaded into the window:
 
-*/
+	```rust,no_run
+	# use sciter::dom::Element;
+	# use sciter::Value;
+	# let hwnd = ::std::ptr::null_mut();
+	let root = Element::from_window(hwnd).unwrap();
+	let result: Value = root.eval_script("... script ...").unwrap();
+	```
 
-	pub use capi::scbehavior::{EVENT_GROUPS, BEHAVIOR_EVENTS, PHASE_MASK};
-  pub use capi::scbehavior::{CLICK_REASON, EDIT_CHANGED_REASON, DRAW_EVENTS};
+	* To call a global function defined in script using its full name (may include the name of namespaces where it resides):
 
-	use capi::sctypes::*;
-	use capi::scdom::HELEMENT;
-	use capi::scgraphics::HGFX;
-	use value::Value;
+	```ignore
+	# #[macro_use] extern crate sciter;
+	# use sciter::Value;
+	# let root = sciter::dom::Element::from(::std::ptr::null_mut());
+	let result: Value = root.call_function("namespace.name", &make_args!(1, "2", 3.0)).unwrap();
+	```
+	The parameters are passed as a `&[Value]` slice.
+
+	* To call a method (function) defined in script for particular DOM element:
+
+	```ignore
+	# #[macro_use] extern crate sciter;
+	# use sciter::Value;
+	# let root = sciter::dom::Element::from(::std::ptr::null_mut());
+	if let Some(el) = root.find_first("input").unwrap() {
+		let result: Value = el.call_method("canUndo", &make_args!()).unwrap();
+	}
+	```
+
+
+	## Calling native code from script
+
+	If needed, your application may expose some [native] functions to be called by script code.
+	Usually this is made by implementing your own `EventHandler` and overriding its `on_script_call` method.
+	If you do this, then you can invoke this callback from script as:
+
+	* "global" native functions: `var r = view.funcName( p0, p1, ... );` – calling
+	`on_script_call` of an `EventHandler` instance attached to the **window**.
+	* As element’s methods: `var r = el.funcName( p0, p1, ... );` – calling
+	`on_script_call` of an `EventHandler` instance (native behavior) attached to the **element**.
+
+	This way you can establish interaction between scipt and native code inside your application.
+
+	*/
+
+	use crate::{
+		capi::{
+			scbehavior::{BEHAVIOR_EVENTS, EVENT_GROUPS, PHASE_MASK},
+			scbehavior::{CLICK_REASON, DRAW_EVENTS, EDIT_CHANGED_REASON},
+			scdom::HELEMENT,
+			scgraphics::HGFX,
+			sctypes::*,
+		},
+		value::Value,
+	};
 
 	/// Default subscription events.
 	///
@@ -1496,33 +1495,32 @@ This way you can establish interaction between scipt and native code inside your
 		/// Edit control change trigger.
 		EditChanged(EDIT_CHANGED_REASON),
 		/// `<video>` request for frame source binding.
-    ///
-    /// See the [`sciter::video`](../../video/index.html) module for more reference.
+		///
+		/// See the [`sciter::video`](../../video/index.html) module for more reference.
 		VideoBind(LPVOID),
 	}
 
-  /// Behavior method params.
-  ///
-  /// Sciter sends these events to native behaviors.
-  #[derive(Debug)]
-  pub enum MethodParams<'a> {
-    /// Click event (either from mouse or code).
-    Click,
+	/// Behavior method params.
+	///
+	/// Sciter sends these events to native behaviors.
+	#[derive(Debug)]
+	pub enum MethodParams<'a> {
+		/// Click event (either from mouse or code).
+		Click,
 
-    /// Get current [`:empty`](https://sciter.com/docs/content/sciter/States.htm) state,
-    /// i.e. if behavior has no children and no text.
-    IsEmpty(&'a mut bool),
+		/// Get current [`:empty`](https://sciter.com/docs/content/sciter/States.htm) state,
+		/// i.e. if behavior has no children and no text.
+		IsEmpty(&'a mut bool),
 
-    /// Get the current value of the behavior.
-    GetValue(&'a mut Value),
+		/// Get the current value of the behavior.
+		GetValue(&'a mut Value),
 
-    /// Set the current value of the behavior.
-    SetValue(Value),
+		/// Set the current value of the behavior.
+		SetValue(Value),
 
-    /// Custom methods, unknown for engine. Sciter will not intrepret it and will do just dispatching.
-    Custom(u32, LPVOID),
-  }
-
+		/// Custom methods, unknown for engine. Sciter will not intrepret it and will do just dispatching.
+		Custom(u32, LPVOID),
+	}
 
 	/// DOM event handler which can be attached to any DOM element.
 	///
@@ -1538,7 +1536,6 @@ This way you can establish interaction between scipt and native code inside your
 	///
 	#[allow(unused_variables)]
 	pub trait EventHandler {
-
 		/// Return a list of event groups this event handler is subscribed to.
 		///
 		/// Default are `HANDLE_BEHAVIOR_EVENT | HANDLE_SCRIPTING_METHOD_CALL | HANDLE_METHOD_CALL`.
@@ -1549,45 +1546,47 @@ This way you can establish interaction between scipt and native code inside your
 
 		/// Called when handler was attached to element or window.
 		/// `root` is `NULL` if attaching to window without loaded document.
-    ///
-    /// **Subscription**: always.
+		///
+		/// **Subscription**: always.
 		fn attached(&mut self, root: HELEMENT) {}
 
 		/// Called when handler was detached from element or window.
-    ///
-    /// **Subscription**: always.
+		///
+		/// **Subscription**: always.
 		fn detached(&mut self, root: HELEMENT) {}
 
 		/// Notification that document finishes its loading - all requests for external resources are finished.
-    ///
-    /// **Subscription**: requires [`HANDLE_BEHAVIOR_EVENT`](enum.EVENT_GROUPS.html),
-    /// but will be sent only for the root element (`<html>`).
+		///
+		/// **Subscription**: requires [`HANDLE_BEHAVIOR_EVENT`](enum.EVENT_GROUPS.html),
+		/// but will be sent only for the root element (`<html>`).
 		fn document_complete(&mut self, root: HELEMENT, target: HELEMENT) {}
 
 		/// The last notification before document removal from the DOM.
-    ///
-    /// **Subscription**: requires [`HANDLE_BEHAVIOR_EVENT`](enum.EVENT_GROUPS.html),
-    /// but will be sent only for the root element (`<html>`).
+		///
+		/// **Subscription**: requires [`HANDLE_BEHAVIOR_EVENT`](enum.EVENT_GROUPS.html),
+		/// but will be sent only for the root element (`<html>`).
 		fn document_close(&mut self, root: HELEMENT, target: HELEMENT) {}
 
-    /// Behavior method calls from script or other behaviors.
-    ///
-    /// Return `false` to skip this event.
-    ///
-    /// **Subscription**: requires [`HANDLE_METHOD_CALL`](enum.EVENT_GROUPS.html).
-    fn on_method_call(&mut self, root: HELEMENT, params: MethodParams) -> bool { return false }
+		/// Behavior method calls from script or other behaviors.
+		///
+		/// Return `false` to skip this event.
+		///
+		/// **Subscription**: requires [`HANDLE_METHOD_CALL`](enum.EVENT_GROUPS.html).
+		fn on_method_call(&mut self, root: HELEMENT, params: MethodParams) -> bool {
+			return false;
+		}
 
 		/// Script calls from CSSS! script and TIScript.
-    ///
-    /// Return `None` to skip this event.
-    ///
-    /// **Subscription**: requires [`HANDLE_SCRIPTING_METHOD_CALL`](enum.EVENT_GROUPS.html).
+		///
+		/// Return `None` to skip this event.
+		///
+		/// **Subscription**: requires [`HANDLE_SCRIPTING_METHOD_CALL`](enum.EVENT_GROUPS.html).
 		fn on_script_call(&mut self, root: HELEMENT, name: &str, args: &[Value]) -> Option<Value> {
 			return self.dispatch_script_call(root, name, args);
 		}
 
 		/// Autogenerated dispatcher for script calls.
-    #[doc(hidden)]
+		#[doc(hidden)]
 		fn dispatch_script_call(&mut self, root: HELEMENT, name: &str, args: &[Value]) -> Option<Value> {
 			return None;
 		}
@@ -1600,34 +1599,45 @@ This way you can establish interaction between scipt and native code inside your
 		}
 
 		/// Notification event from builtin behaviors.
-    ///
-    /// Return `false` to skip this event.
-    ///
-    /// **Subscription**: requires [`HANDLE_BEHAVIOR_EVENT`](enum.EVENT_GROUPS.html).
-		fn on_event(&mut self, root: HELEMENT, source: HELEMENT, target: HELEMENT, code: BEHAVIOR_EVENTS, phase: PHASE_MASK, reason: EventReason) -> bool {
+		///
+		/// Return `false` to skip this event.
+		///
+		/// **Subscription**: requires [`HANDLE_BEHAVIOR_EVENT`](enum.EVENT_GROUPS.html).
+		fn on_event(
+			&mut self,
+			root: HELEMENT,
+			source: HELEMENT,
+			target: HELEMENT,
+			code: BEHAVIOR_EVENTS,
+			phase: PHASE_MASK,
+			reason: EventReason,
+		) -> bool {
 			return false;
 		}
 
 		/// Timer event from attached element.
-    ///
-    /// Return `false` to skip this event.
-    ///
-    /// **Subscription**: requires [`HANDLE_TIMER`](enum.EVENT_GROUPS.html).
-		fn on_timer(&mut self, root: HELEMENT, timer_id: u64) -> bool { return false; }
+		///
+		/// Return `false` to skip this event.
+		///
+		/// **Subscription**: requires [`HANDLE_TIMER`](enum.EVENT_GROUPS.html).
+		fn on_timer(&mut self, root: HELEMENT, timer_id: u64) -> bool {
+			return false;
+		}
 
 		/// Drawing request event.
 		///
 		/// It allows to intercept drawing events of an `Element` and to manually draw its content, background and foreground layers.
-    ///
-    /// Return `false` to skip this event.
-    ///
-    /// **Subscription**: requires [`HANDLE_DRAW`](enum.EVENT_GROUPS.html).
-		fn on_draw(&mut self, root: HELEMENT, gfx: HGFX, area: &RECT, layer: DRAW_EVENTS) -> bool { return false; }
+		///
+		/// Return `false` to skip this event.
+		///
+		/// **Subscription**: requires [`HANDLE_DRAW`](enum.EVENT_GROUPS.html).
+		fn on_draw(&mut self, root: HELEMENT, gfx: HGFX, area: &RECT, layer: DRAW_EVENTS) -> bool {
+			return false;
+		}
 
 		/// Size changed event.
-    ///
-    /// **Subscription**: requires [`HANDLE_SIZE`](enum.EVENT_GROUPS.html).
+		///
+		/// **Subscription**: requires [`HANDLE_SIZE`](enum.EVENT_GROUPS.html).
 		fn on_size(&mut self, root: HELEMENT) {}
 	}
-
 }

--- a/src/eventhandler.rs
+++ b/src/eventhandler.rs
@@ -1,12 +1,11 @@
-use capi::sctypes::*;
-use capi::scbehavior::*;
-use capi::scdom::{HELEMENT};
-use value::Value;
-use dom::event::EventHandler;
+use crate::capi::scbehavior::*;
+use crate::capi::scdom::HELEMENT;
+use crate::capi::sctypes::*;
+use crate::dom::event::EventHandler;
+use crate::value::Value;
 
 #[repr(C)]
-pub(crate) struct WindowHandler<T>
-{
+pub(crate) struct WindowHandler<T> {
 	pub hwnd: HWINDOW,
 	pub handler: T,
 }
@@ -17,7 +16,7 @@ pub(crate) struct BoxedHandler {
 }
 
 fn is_detach_event(evtg: UINT, params: LPVOID) -> bool {
-	let evtg : EVENT_GROUPS = unsafe { ::std::mem::transmute(evtg) };
+	let evtg: EVENT_GROUPS = unsafe { ::std::mem::transmute(evtg) };
 	if evtg == EVENT_GROUPS::HANDLE_INITIALIZATION {
 		assert!(!params.is_null());
 		let scnm = params as *const INITIALIZATION_EVENTS;
@@ -29,12 +28,16 @@ fn is_detach_event(evtg: UINT, params: LPVOID) -> bool {
 	false
 }
 
-pub(crate) extern "system" fn _event_handler_window_proc<T: EventHandler>(tag: LPVOID, _he: ::capi::scdom::HELEMENT, evtg: UINT, params: LPVOID) -> BOOL
-{
+pub(crate) extern "system" fn _event_handler_window_proc<T: EventHandler>(
+	tag: LPVOID,
+	_he: crate::capi::scdom::HELEMENT,
+	evtg: UINT,
+	params: LPVOID,
+) -> BOOL {
 	let boxed = tag as *mut WindowHandler<T>;
 	let tuple: &mut WindowHandler<T> = unsafe { &mut *boxed };
 
-	let hroot: HELEMENT = if let Ok(root) = ::dom::Element::from_window(tuple.hwnd) {
+	let hroot: HELEMENT = if let Ok(root) = crate::dom::Element::from_window(tuple.hwnd) {
 		root.as_ptr()
 	} else {
 		::std::ptr::null_mut()
@@ -73,8 +76,7 @@ pub(crate) extern "system" fn _event_handler_behavior_proc(tag: LPVOID, he: HELE
 	process_events(me, he, evtg, params)
 }
 
-pub(crate) extern "system" fn _event_handler_proc<T: EventHandler>(tag: LPVOID, he: HELEMENT, evtg: UINT, params: LPVOID) -> BOOL
-{
+pub(crate) extern "system" fn _event_handler_proc<T: EventHandler>(tag: LPVOID, he: HELEMENT, evtg: UINT, params: LPVOID) -> BOOL {
 	// reconstruct pointer to Handler
 	let boxed = tag as *mut T;
 	let me = unsafe { &mut *boxed };
@@ -92,30 +94,28 @@ pub(crate) extern "system" fn _event_handler_proc<T: EventHandler>(tag: LPVOID, 
 	process_events(me, he, evtg, params)
 }
 
-fn process_events(me: &mut dyn EventHandler, he: HELEMENT, evtg: UINT, params: LPVOID) -> BOOL
-{
-	let evtg : EVENT_GROUPS = unsafe { ::std::mem::transmute(evtg) };
+fn process_events(me: &mut dyn EventHandler, he: HELEMENT, evtg: UINT, params: LPVOID) -> BOOL {
+	let evtg: EVENT_GROUPS = unsafe { ::std::mem::transmute(evtg) };
 	if he.is_null()
 		&& evtg != EVENT_GROUPS::SUBSCRIPTIONS_REQUEST
 		&& evtg != EVENT_GROUPS::HANDLE_BEHAVIOR_EVENT
 		&& evtg != EVENT_GROUPS::HANDLE_INITIALIZATION
 		&& evtg != EVENT_GROUPS::HANDLE_SOM
 	{
-		eprintln!("[sciter] warning! null element for {:04X}", evtg as u32);
+		eprintln!("[sciter] warning! null element for {:04X}", evtg);
 	}
 
 	let result = match evtg {
-
 		EVENT_GROUPS::SUBSCRIPTIONS_REQUEST => {
 			assert!(!params.is_null());
 			let scnm = params as *mut EVENT_GROUPS;
-			let nm = unsafe {&mut *scnm};
+			let nm = unsafe { &mut *scnm };
 			let handled = me.get_subscription();
 			if let Some(needed) = handled {
 				*nm = needed;
 			}
 			handled.is_some()
-		},
+		}
 
 		EVENT_GROUPS::HANDLE_INITIALIZATION => {
 			assert!(!params.is_null());
@@ -124,14 +124,14 @@ fn process_events(me: &mut dyn EventHandler, he: HELEMENT, evtg: UINT, params: L
 			match nm.cmd {
 				INITIALIZATION_EVENTS::BEHAVIOR_DETACH => {
 					me.detached(he);
-				},
+				}
 
 				INITIALIZATION_EVENTS::BEHAVIOR_ATTACH => {
 					me.attached(he);
-				},
+				}
 			};
 			true
-		},
+		}
 
 		EVENT_GROUPS::HANDLE_SOM => {
 			assert!(!params.is_null());
@@ -143,39 +143,36 @@ fn process_events(me: &mut dyn EventHandler, he: HELEMENT, evtg: UINT, params: L
 						nm.result.passport = asset.get_passport();
 						return true as BOOL;
 					}
-				},
+				}
 
 				SOM_EVENTS::SOM_GET_ASSET => {
 					if let Some(asset) = me.get_asset() {
 						nm.result.asset = asset;
 						return true as BOOL;
 					}
-				},
+				}
 			};
 			false
-		},
-
+		}
 
 		EVENT_GROUPS::HANDLE_BEHAVIOR_EVENT => {
 			assert!(!params.is_null());
 			let scnm = params as *const BEHAVIOR_EVENT_PARAMS;
 			let nm = unsafe { &*scnm };
 
-      use dom::event::EventReason;
-			let code :BEHAVIOR_EVENTS = unsafe{ ::std::mem::transmute(nm.cmd & 0x0_0FFF) };
+			use crate::dom::event::EventReason;
+			let code: BEHAVIOR_EVENTS = unsafe { ::std::mem::transmute(nm.cmd & 0x0_0FFF) };
 			let phase: PHASE_MASK = unsafe { ::std::mem::transmute(nm.cmd & 0xFFFF_F000) };
 			let reason = match code {
 				BEHAVIOR_EVENTS::EDIT_VALUE_CHANGED | BEHAVIOR_EVENTS::EDIT_VALUE_CHANGING => {
-					let reason: EDIT_CHANGED_REASON = unsafe{ ::std::mem::transmute(nm.reason as UINT) };
+					let reason: EDIT_CHANGED_REASON = unsafe { ::std::mem::transmute(nm.reason as UINT) };
 					EventReason::EditChanged(reason)
-				},
-
-				BEHAVIOR_EVENTS::VIDEO_BIND_RQ => {
-					EventReason::VideoBind(nm.reason as LPVOID)
 				}
 
+				BEHAVIOR_EVENTS::VIDEO_BIND_RQ => EventReason::VideoBind(nm.reason as LPVOID),
+
 				_ => {
-					let reason: CLICK_REASON = unsafe{ ::std::mem::transmute(nm.reason as UINT) };
+					let reason: CLICK_REASON = unsafe { ::std::mem::transmute(nm.reason as UINT) };
 					EventReason::General(reason)
 				}
 			};
@@ -184,28 +181,29 @@ fn process_events(me: &mut dyn EventHandler, he: HELEMENT, evtg: UINT, params: L
 				eprintln!("[sciter] warning! null element for {:?}:{:?}", evtg, code);
 			}
 
-			if phase == PHASE_MASK::SINKING {	// catch this only once
+			if phase == PHASE_MASK::SINKING {
+				// catch this only once
 				match code {
 					BEHAVIOR_EVENTS::DOCUMENT_COMPLETE => {
 						me.document_complete(he, nm.heTarget);
-					},
+					}
 					BEHAVIOR_EVENTS::DOCUMENT_CLOSE => {
 						me.document_close(he, nm.heTarget);
-					},
-					_ => ()
+					}
+					_ => (),
 				};
 			}
 
 			let handled = me.on_event(he, nm.he, nm.heTarget, code, phase, reason);
 			handled
-		},
+		}
 
 		EVENT_GROUPS::HANDLE_SCRIPTING_METHOD_CALL => {
 			assert!(!params.is_null());
 			let scnm = params as *mut SCRIPTING_METHOD_PARAMS;
 			let nm = unsafe { &mut *scnm };
 			let name = u2s!(nm.name);
-			let argv = unsafe { Value::unpack_from(nm.argv, nm.argc) };
+			let argv = Value::unpack_from(nm.argv, nm.argc);
 			let rv = me.on_script_call(he, &name, &argv);
 			let handled = if let Some(v) = rv {
 				v.pack_to(&mut nm.result);
@@ -214,87 +212,78 @@ fn process_events(me: &mut dyn EventHandler, he: HELEMENT, evtg: UINT, params: L
 				false
 			};
 			handled
-		},
+		}
 
-    EVENT_GROUPS::HANDLE_METHOD_CALL => {
-      assert!(!params.is_null());
-      let scnm = params as *const METHOD_PARAMS;
-      let nm = unsafe { & *scnm };
-      let code: BEHAVIOR_METHOD_IDENTIFIERS = unsafe { ::std::mem::transmute((*nm).method) };
-      use capi::scbehavior::BEHAVIOR_METHOD_IDENTIFIERS::*;
+		EVENT_GROUPS::HANDLE_METHOD_CALL => {
+			assert!(!params.is_null());
+			let scnm = params as *const METHOD_PARAMS;
+			let nm = unsafe { &*scnm };
+			let code: BEHAVIOR_METHOD_IDENTIFIERS = unsafe { ::std::mem::transmute((*nm).method) };
+			use crate::capi::scbehavior::BEHAVIOR_METHOD_IDENTIFIERS::*;
 
-      // output values
-      let mut method_value = Value::new();
-      let mut is_empty = false;
+			// output values
+			let mut method_value = Value::new();
+			let mut is_empty = false;
 
-      let handled = {
+			let handled = {
+				// unpack method parameters
+				use crate::dom::event::MethodParams;
+				let reason = match code {
+					DO_CLICK => MethodParams::Click,
+					IS_EMPTY => MethodParams::IsEmpty(&mut is_empty),
+					GET_VALUE => MethodParams::GetValue(&mut method_value),
+					SET_VALUE => {
+						// Value from Sciter.
+						let payload = params as *const VALUE_PARAMS;
+						let pm = unsafe { &*payload };
+						MethodParams::SetValue(Value::from(&pm.value))
+					}
 
-        // unpack method parameters
-        use dom::event::MethodParams;
-        let reason = match code {
-          DO_CLICK => {
-            MethodParams::Click
-          },
-          IS_EMPTY => {
-            MethodParams::IsEmpty(&mut is_empty)
-          },
-          GET_VALUE => {
-            MethodParams::GetValue(&mut method_value)
-          },
-          SET_VALUE => {
-            // Value from Sciter.
-            let payload = params as *const VALUE_PARAMS;
-            let pm = unsafe { & *payload };
-            MethodParams::SetValue(Value::from(&pm.value))
-          },
+					_ => MethodParams::Custom((*nm).method, params),
+				};
 
-          _ => {
-            MethodParams::Custom((*nm).method, params)
-          },
-        };
+				// call event handler
+				let handled = me.on_method_call(he, reason);
+				handled
+			};
 
-        // call event handler
-        let handled = me.on_method_call(he, reason);
-        handled
-      };
+			if handled {
+				// Pack values back to Sciter.
+				match code {
+					GET_VALUE => {
+						let payload = params as *mut VALUE_PARAMS;
+						let pm = unsafe { &mut *payload };
+						method_value.pack_to(&mut pm.value);
+					}
 
-      if handled {
-        // Pack values back to Sciter.
-        match code {
-          GET_VALUE => {
-            let payload = params as *mut VALUE_PARAMS;
-            let pm = unsafe { &mut *payload };
-            method_value.pack_to(&mut pm.value);
-          },
+					IS_EMPTY => {
+						let payload = params as *mut IS_EMPTY_PARAMS;
+						let pm = unsafe { &mut *payload };
+						pm.is_empty = is_empty as UINT;
+					}
 
-          IS_EMPTY => {
-            let payload = params as *mut IS_EMPTY_PARAMS;
-            let pm = unsafe { &mut *payload };
-            pm.is_empty = is_empty as UINT;
-          },
-
-          _ => {},
-        }
-      }
-      // we've done here
-      handled
-    },
+					_ => {}
+				}
+			}
+			// we've done here
+			handled
+		}
 
 		EVENT_GROUPS::HANDLE_TIMER => {
 			assert!(!params.is_null());
 			let scnm = params as *const TIMER_PARAMS;
-			let nm = unsafe { & *scnm };
+			let nm = unsafe { &*scnm };
 			let handled = me.on_timer(he, nm.timerId as u64);
 			handled
-		},
+		}
 
 		EVENT_GROUPS::HANDLE_DRAW => {
 			assert!(!params.is_null());
 			let scnm = params as *const DRAW_PARAMS;
-			let nm = unsafe { & *scnm };
+			let nm = unsafe { &*scnm };
 			let handled = me.on_draw(he, nm.gfx, &nm.area, nm.layer);
 			handled
-		},
+		}
 
 		// known notifications:
 		EVENT_GROUPS::HANDLE_MOUSE
@@ -312,9 +301,9 @@ fn process_events(me: &mut dyn EventHandler, he: HELEMENT, evtg: UINT, params: L
 
 		// unknown `EVENT_GROUPS` notification
 		_ => {
-			eprintln!("[sciter] warning! unknown event group {:04X}", evtg as u32);
+			eprintln!("[sciter] warning! unknown event group {:04X}", evtg);
 			false
-		},
+		}
 	};
 	return result as BOOL;
 }

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -5,39 +5,34 @@ Essentially this mimics [`Graphics`](https://sciter.com/docs/content/sciter/Grap
 scripting object as close as possible.
 
 */
-use capi::scgraphics::{HTEXT, HIMG, HPATH};
-use capi::scgraphics::{SC_ANGLE, SC_COLOR, SC_COLOR_STOP, SC_DIM, SC_POS};
-use capi::sctypes::{BOOL, LPCBYTE, LPVOID, POINT, SIZE, UINT};
-use std::ptr::{null_mut, null};
-use value::{FromValue, Value};
-use dom::Element;
-use _GAPI;
+use crate::_GAPI;
+use crate::capi::scgraphics::{HIMG, HPATH, HTEXT};
+use crate::capi::scgraphics::{SC_ANGLE, SC_COLOR, SC_COLOR_STOP, SC_DIM, SC_POS};
+use crate::capi::sctypes::{BOOL, LPCBYTE, LPVOID, POINT, SIZE, UINT};
+use crate::dom::Element;
+use crate::value::{FromValue, Value};
+use std::ptr::{null, null_mut};
 
-pub use capi::scgraphics::{HGFX, GRAPHIN_RESULT};
-pub use capi::scgraphics::{DRAW_PATH, LINE_CAP, LINE_JOIN};
+pub use crate::capi::scgraphics::{DRAW_PATH, LINE_CAP, LINE_JOIN};
+pub use crate::capi::scgraphics::{GRAPHIN_RESULT, HGFX};
 
 /// Supported image encodings for [`Image.save()`](struct.Image.html#method.save).
-#[derive(Clone, Copy)]
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SaveImageEncoding {
-  /// Raw bitmap in a `[a,b,g,r, a,b,g,r, ...]` form.
-  Raw,
-  /// Portable Network Graphics format.
-  Png,
-  /// JPEG with the specified quality level (in range of `10..100`).
-  Jpeg(u8),
-  /// WebP with the specified quality level (in range of `0..100`, where `0` means a lossless compression).
-  Webp(u8),
+	/// Raw bitmap in a `[a,b,g,r, a,b,g,r, ...]` form.
+	Raw,
+	/// Portable Network Graphics format.
+	Png,
+	/// JPEG with the specified quality level (in range of `10..100`).
+	Jpeg(u8),
+	/// WebP with the specified quality level (in range of `0..100`, where `0` means a lossless compression).
+	Webp(u8),
 }
 
 macro_rules! ok_or {
-  ($rv:expr, $ok:ident) => {
-    if $ok == GRAPHIN_RESULT::OK {
-      Ok($rv)
-    } else {
-      Err($ok)
-    }
-  };
+	($rv:expr, $ok:ident) => {
+		if $ok == GRAPHIN_RESULT::OK { Ok($rv) } else { Err($ok) }
+	};
 }
 
 /// A specialized `Result` type for graphics operations.
@@ -60,15 +55,14 @@ pub type Dim = SC_DIM;
 
 /// Construct a color value (in `RGBA` form) from the `red`, `green` and `blue` components.
 pub fn rgb(red: u8, green: u8, blue: u8) -> Color {
-  (_GAPI.RGBA)(u32::from(red), u32::from(green), u32::from(blue), 255)
+	(_GAPI.RGBA)(u32::from(red), u32::from(green), u32::from(blue), 255)
 }
 
 /// Construct a color value (in `RGBA` form) from the `red`, `green`, `blue` and `opacity` components.
 pub fn rgba((r, g, b): (u8, u8, u8), opacity: u8) -> Color {
 	let color = rgb(r, g, b);
-  u32::from(opacity) | color << 24
+	u32::from(opacity) | color << 24
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // Text
@@ -106,35 +100,35 @@ impl Drop for Text {
 ///
 /// All allocated objects are reference counted so copying is just a matter of increasing reference counts.
 impl Clone for Text {
-  fn clone(&self) -> Self {
-    let dst = Text(self.0);
-    (_GAPI.textAddRef)(dst.0);
-    dst
-  }
+	fn clone(&self) -> Self {
+		let dst = Text(self.0);
+		(_GAPI.textAddRef)(dst.0);
+		dst
+	}
 }
 
 /// Get a `Text` object contained in the `Value`.
 impl FromValue for Text {
-  fn from_value(v: &Value) -> Option<Text> {
-    let mut h = null_mut();
-    let ok = (_GAPI.vUnWrapText)(v.as_cptr(), &mut h);
-    if ok == GRAPHIN_RESULT::OK {
-      (_GAPI.textAddRef)(h);
-      Some(Text(h))
-    } else {
-      None
-    }
-  }
+	fn from_value(v: &Value) -> Option<Text> {
+		let mut h = null_mut();
+		let ok = (_GAPI.vUnWrapText)(v.as_cptr(), &mut h);
+		if ok == GRAPHIN_RESULT::OK {
+			(_GAPI.textAddRef)(h);
+			Some(Text(h))
+		} else {
+			None
+		}
+	}
 }
 
 /// Store the `Text` object as a `Value`.
 impl From<Text> for Value {
-  fn from(i: Text) -> Value {
-    let mut v = Value::new();
-    let ok = (_GAPI.vWrapText)(i.0, v.as_ptr());
-    assert!(ok == GRAPHIN_RESULT::OK);
-    v
-  }
+	fn from(i: Text) -> Value {
+		let mut v = Value::new();
+		let ok = (_GAPI.vWrapText)(i.0, v.as_ptr());
+		assert!(ok == GRAPHIN_RESULT::OK);
+		v
+	}
 }
 
 impl Text {
@@ -151,7 +145,7 @@ impl Text {
 		let (t, tn) = s2wn!(text);
 		let (c, _cn) = s2wn!(class);
 		let mut h = null_mut();
-		let ok = (_GAPI.textCreateForElement)(&mut h, t.as_ptr(), tn, e.as_ptr(), c.as_ptr() );
+		let ok = (_GAPI.textCreateForElement)(&mut h, t.as_ptr(), tn, e.as_ptr(), c.as_ptr());
 		ok_or!(Text(h), ok)
 	}
 
@@ -173,12 +167,15 @@ impl Text {
 	/// Returns metrics of the text layout object.
 	pub fn get_metrics(&self) -> Result<TextMetrics> {
 		let mut tm = TextMetrics::default();
-		let ok = (_GAPI.textGetMetrics)(self.0,
-				&mut tm.min_width, &mut tm.max_width,
-				&mut tm.height,
-				&mut tm.ascent, &mut tm.descent,
-				&mut tm.lines,
-			);
+		let ok = (_GAPI.textGetMetrics)(
+			self.0,
+			&mut tm.min_width,
+			&mut tm.max_width,
+			&mut tm.height,
+			&mut tm.ascent,
+			&mut tm.descent,
+			&mut tm.lines,
+		);
 		ok_or!(tm, ok)
 	}
 }
@@ -191,181 +188,181 @@ pub struct Image(HIMG);
 
 /// Destroy pointed image object.
 impl Drop for Image {
-  fn drop(&mut self) {
-    (_GAPI.imageRelease)(self.0);
-  }
+	fn drop(&mut self) {
+		(_GAPI.imageRelease)(self.0);
+	}
 }
 
 /// Copies image object.
 ///
 /// All allocated objects are reference counted so copying is just a matter of increasing reference counts.
 impl Clone for Image {
-  fn clone(&self) -> Self {
-    let dst = Image(self.0);
-    (_GAPI.imageAddRef)(dst.0);
-    dst
-  }
+	fn clone(&self) -> Self {
+		let dst = Image(self.0);
+		(_GAPI.imageAddRef)(dst.0);
+		dst
+	}
 }
 
 /// Get an `Image` object contained in the `Value`.
 impl FromValue for Image {
-  fn from_value(v: &Value) -> Option<Image> {
-    let mut h = null_mut();
-    let ok = (_GAPI.vUnWrapImage)(v.as_cptr(), &mut h);
-    if ok == GRAPHIN_RESULT::OK {
-    	(_GAPI.imageAddRef)(h);
-      Some(Image(h))
-    } else {
-      None
-    }
-  }
+	fn from_value(v: &Value) -> Option<Image> {
+		let mut h = null_mut();
+		let ok = (_GAPI.vUnWrapImage)(v.as_cptr(), &mut h);
+		if ok == GRAPHIN_RESULT::OK {
+			(_GAPI.imageAddRef)(h);
+			Some(Image(h))
+		} else {
+			None
+		}
+	}
 }
 
 /// Store the `Image` object as a `Value`.
 impl From<Image> for Value {
-  fn from(i: Image) -> Value {
-    let mut v = Value::new();
-    let ok = (_GAPI.vWrapImage)(i.0, v.as_ptr());
-    assert!(ok == GRAPHIN_RESULT::OK);
-    v
-  }
+	fn from(i: Image) -> Value {
+		let mut v = Value::new();
+		let ok = (_GAPI.vWrapImage)(i.0, v.as_ptr());
+		assert!(ok == GRAPHIN_RESULT::OK);
+		v
+	}
 }
 
 impl Image {
-  /// Create a new blank image.
-  pub fn create((width, height): (u32, u32), with_alpha: bool) -> Result<Image> {
-    let mut h = null_mut();
-    let ok = (_GAPI.imageCreate)(&mut h, width, height, with_alpha as BOOL);
-    ok_or!(Image(h), ok)
-  }
+	/// Create a new blank image.
+	pub fn create((width, height): (u32, u32), with_alpha: bool) -> Result<Image> {
+		let mut h = null_mut();
+		let ok = (_GAPI.imageCreate)(&mut h, width, height, with_alpha as BOOL);
+		ok_or!(Image(h), ok)
+	}
 
-  /// Create a new blank image.
-  #[deprecated(note="Use `Image::create` instead.")]
-  pub fn new((width, height): (u32, u32), with_alpha: bool) -> Result<Image> {
-  	Self::create((width, height), with_alpha)
-  }
+	/// Create a new blank image.
+	#[deprecated(note = "Use `Image::create` instead.")]
+	pub fn new((width, height): (u32, u32), with_alpha: bool) -> Result<Image> {
+		Self::create((width, height), with_alpha)
+	}
 
-  /// Create image from `BGRA` data. Size of the pixmap is `width * height * 4` bytes.
-  pub fn with_data((width, height): (u32, u32), with_alpha: bool, pixmap: &[u8]) -> Result<Image> {
-    let mut h = null_mut();
-    let ok = (_GAPI.imageCreateFromPixmap)(&mut h, width, height, with_alpha as BOOL, pixmap.as_ptr());
-    ok_or!(Image(h), ok)
-  }
+	/// Create image from `BGRA` data. Size of the pixmap is `width * height * 4` bytes.
+	pub fn with_data((width, height): (u32, u32), with_alpha: bool, pixmap: &[u8]) -> Result<Image> {
+		let mut h = null_mut();
+		let ok = (_GAPI.imageCreateFromPixmap)(&mut h, width, height, with_alpha as BOOL, pixmap.as_ptr());
+		ok_or!(Image(h), ok)
+	}
 
-  /// Load image from memory.
-  ///
-  /// Supported formats are: GIF, JPEG, PNG, WebP. On Windows also are BMP, ICO, TIFF and WMP.
-  pub fn load(image_data: &[u8]) -> Result<Image> {
-    let mut h = null_mut();
-    let ok = (_GAPI.imageLoad)(image_data.as_ptr(), image_data.len() as UINT, &mut h);
-    ok_or!(Image(h), ok)
-  }
+	/// Load image from memory.
+	///
+	/// Supported formats are: GIF, JPEG, PNG, WebP. On Windows also are BMP, ICO, TIFF and WMP.
+	pub fn load(image_data: &[u8]) -> Result<Image> {
+		let mut h = null_mut();
+		let ok = (_GAPI.imageLoad)(image_data.as_ptr(), image_data.len() as UINT, &mut h);
+		ok_or!(Image(h), ok)
+	}
 
-  /// Save content of the image as a byte vector.
-  pub fn save(&self, encoding: SaveImageEncoding) -> Result<Vec<u8>> {
-    extern "system" fn on_save(prm: LPVOID, data: LPCBYTE, data_length: UINT) {
-      assert!(!prm.is_null());
-      assert!(!data.is_null());
-      unsafe {
-        let param = prm as *mut Vec<u8>;
-        let dst = &mut *param;
-        let src = ::std::slice::from_raw_parts(data, data_length as usize);
-        dst.extend_from_slice(src);
-      }
-    }
-    use capi::scgraphics::IMAGE_ENCODING::*;
-    let (enc, q) = match encoding {
-      SaveImageEncoding::Raw => (RAW, 0),
-      SaveImageEncoding::Png => (PNG, 0),
-      SaveImageEncoding::Jpeg(q) => (JPG, q),
-      SaveImageEncoding::Webp(q) => (WEBP, q),
-    };
-    let mut data = Vec::new();
-    let ok = (_GAPI.imageSave)(self.0, on_save, &mut data as *mut _ as LPVOID, enc, u32::from(q));
-    ok_or!(data, ok)
-  }
+	/// Save content of the image as a byte vector.
+	pub fn save(&self, encoding: SaveImageEncoding) -> Result<Vec<u8>> {
+		extern "system" fn on_save(prm: LPVOID, data: LPCBYTE, data_length: UINT) {
+			assert!(!prm.is_null());
+			assert!(!data.is_null());
+			unsafe {
+				let param = prm as *mut Vec<u8>;
+				let dst = &mut *param;
+				let src = ::std::slice::from_raw_parts(data, data_length as usize);
+				dst.extend_from_slice(src);
+			}
+		}
+		use crate::capi::scgraphics::IMAGE_ENCODING::*;
+		let (enc, q) = match encoding {
+			SaveImageEncoding::Raw => (RAW, 0),
+			SaveImageEncoding::Png => (PNG, 0),
+			SaveImageEncoding::Jpeg(q) => (JPG, q),
+			SaveImageEncoding::Webp(q) => (WEBP, q),
+		};
+		let mut data = Vec::new();
+		let ok = (_GAPI.imageSave)(self.0, on_save, &mut data as *mut _ as LPVOID, enc, u32::from(q));
+		ok_or!(data, ok)
+	}
 
-  /// Render on bitmap image using methods of the [`Graphics`](struct.Graphics.html) object.
-  ///
-  /// The image must be created using [`Image::new()`](struct.Image.html#method.new) or
-  /// [`Image::with_data()`](struct.Image.html#method.with_data) methods
-  /// or loaded from a [BMP](https://en.wikipedia.org/wiki/BMP_file_format) file.
-  ///
-  /// `PaintFn` painter type must be the following:
-  ///
-  /// ```rust
-  /// use sciter::graphics::{Graphics, Result};
-  ///
-  /// fn paint(gfx: &mut Graphics, (width, height): (f32, f32)) -> Result<()>
-  /// # { Ok(()) }
-  /// ```
-  ///
-  /// Note that errors inside painter are promoted back to the caller of the `paint()`.
-  ///
-  /// # Example:
-  ///
-  /// ```rust
-  /// # use sciter::graphics::Image;
-  /// let mut image = Image::new((100, 100), false).unwrap();
-  /// image.paint(|gfx, size| {
-  ///   gfx.rectangle((5.0, 5.0), (size.0 - 5.0, size.1 - 5.0))?;
-  ///   Ok(())
-  /// }).unwrap();
-  /// ```
-  pub fn paint<PaintFn>(&mut self, painter: PaintFn) -> Result<()>
-  where
-    PaintFn: Fn(&mut Graphics, (f32, f32)) -> Result<()>,
-  {
-    #[repr(C)]
-    struct Payload<PaintFn> {
-      painter: PaintFn,
-      result: Result<()>,
-    }
-    extern "system" fn on_paint<PaintFn: Fn(&mut Graphics, (f32, f32)) -> Result<()>>(prm: LPVOID, hgfx: HGFX, width: UINT, height: UINT) {
-      let param = prm as *mut Payload<PaintFn>;
-      assert!(!param.is_null());
-      assert!(!hgfx.is_null());
-    	let payload = unsafe { &mut *param };
-      let ok = if !hgfx.is_null() {
-      	let mut gfx = Graphics::from(hgfx);
-      	(payload.painter)(&mut gfx, (width as f32, height as f32))
-      } else {
-      	Err(GRAPHIN_RESULT::BAD_PARAM)
-      };
-      payload.result = ok;
-    }
-    let payload = Payload {
-      painter: painter,
-      result: Ok(()),
-    };
-    let param = Box::new(payload);
-    let param = Box::into_raw(param);
-    let ok = (_GAPI.imagePaint)(self.0, on_paint::<PaintFn>, param as LPVOID);
-    let ok = ok_or!((), ok);
-    let param = unsafe { Box::from_raw(param) };
-    ok.and(param.result)
-  }
+	/// Render on bitmap image using methods of the [`Graphics`](struct.Graphics.html) object.
+	///
+	/// The image must be created using [`Image::new()`](struct.Image.html#method.new) or
+	/// [`Image::with_data()`](struct.Image.html#method.with_data) methods
+	/// or loaded from a [BMP](https://en.wikipedia.org/wiki/BMP_file_format) file.
+	///
+	/// `PaintFn` painter type must be the following:
+	///
+	/// ```rust
+	/// use sciter::graphics::{Graphics, Result};
+	///
+	/// fn paint(gfx: &mut Graphics, (width, height): (f32, f32)) -> Result<()>
+	/// # { Ok(()) }
+	/// ```
+	///
+	/// Note that errors inside painter are promoted back to the caller of the `paint()`.
+	///
+	/// # Example:
+	///
+	/// ```rust
+	/// # use sciter::graphics::Image;
+	/// let mut image = Image::new((100, 100), false).unwrap();
+	/// image.paint(|gfx, size| {
+	///   gfx.rectangle((5.0, 5.0), (size.0 - 5.0, size.1 - 5.0))?;
+	///   Ok(())
+	/// }).unwrap();
+	/// ```
+	pub fn paint<PaintFn>(&mut self, painter: PaintFn) -> Result<()>
+	where
+		PaintFn: Fn(&mut Graphics, (f32, f32)) -> Result<()>,
+	{
+		#[repr(C)]
+		struct Payload<PaintFn> {
+			painter: PaintFn,
+			result: Result<()>,
+		}
+		extern "system" fn on_paint<PaintFn: Fn(&mut Graphics, (f32, f32)) -> Result<()>>(prm: LPVOID, hgfx: HGFX, width: UINT, height: UINT) {
+			let param = prm as *mut Payload<PaintFn>;
+			assert!(!param.is_null());
+			assert!(!hgfx.is_null());
+			let payload = unsafe { &mut *param };
+			let ok = if !hgfx.is_null() {
+				let mut gfx = Graphics::from(hgfx);
+				(payload.painter)(&mut gfx, (width as f32, height as f32))
+			} else {
+				Err(GRAPHIN_RESULT::BAD_PARAM)
+			};
+			payload.result = ok;
+		}
+		let payload = Payload {
+			painter: painter,
+			result: Ok(()),
+		};
+		let param = Box::new(payload);
+		let param = Box::into_raw(param);
+		let ok = (_GAPI.imagePaint)(self.0, on_paint::<PaintFn>, param as LPVOID);
+		let ok = ok_or!((), ok);
+		let param = unsafe { Box::from_raw(param) };
+		ok.and(param.result)
+	}
 
-  /// Get width and height of the image (in pixels).
-  pub fn dimensions(&self) -> Result<(u32, u32)> {
-    let mut alpha = 0;
-    let mut w = 0;
-    let mut h = 0;
-    let ok = (_GAPI.imageGetInfo)(self.0, &mut w, &mut h, &mut alpha);
-    ok_or!((w, h), ok)
-  }
+	/// Get width and height of the image (in pixels).
+	pub fn dimensions(&self) -> Result<(u32, u32)> {
+		let mut alpha = 0;
+		let mut w = 0;
+		let mut h = 0;
+		let ok = (_GAPI.imageGetInfo)(self.0, &mut w, &mut h, &mut alpha);
+		ok_or!((w, h), ok)
+	}
 
-  /// Clear image by filling it with the black color.
-  pub fn clear(&mut self) -> Result<()> {
-    let ok = (_GAPI.imageClear)(self.0, Graphics::NO_COLOR);
-    ok_or!((), ok)
-  }
+	/// Clear image by filling it with the black color.
+	pub fn clear(&mut self) -> Result<()> {
+		let ok = (_GAPI.imageClear)(self.0, Graphics::NO_COLOR);
+		ok_or!((), ok)
+	}
 
-  /// Clear image by filling it with the specified `color`.
-  pub fn clear_with(&mut self, color: Color) -> Result<()> {
-    let ok = (_GAPI.imageClear)(self.0, color);
-    ok_or!((), ok)
-  }
+	/// Clear image by filling it with the specified `color`.
+	pub fn clear_with(&mut self, color: Color) -> Result<()> {
+		let ok = (_GAPI.imageClear)(self.0, color);
+		ok_or!((), ok)
+	}
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -376,122 +373,122 @@ pub struct Path(HPATH);
 
 /// Destroy pointed path object.
 impl Drop for Path {
-  fn drop(&mut self) {
-    (_GAPI.pathRelease)(self.0);
-  }
+	fn drop(&mut self) {
+		(_GAPI.pathRelease)(self.0);
+	}
 }
 
 /// Copies path object.
 ///
 /// All allocated objects are reference counted so copying is just a matter of increasing reference counts.
 impl Clone for Path {
-  fn clone(&self) -> Self {
-    let dst = Path(self.0);
-    (_GAPI.pathAddRef)(dst.0);
-    dst
-  }
+	fn clone(&self) -> Self {
+		let dst = Path(self.0);
+		(_GAPI.pathAddRef)(dst.0);
+		dst
+	}
 }
 
 /// Get a `Path` object contained in the `Value`.
 impl FromValue for Path {
-  fn from_value(v: &Value) -> Option<Path> {
-    let mut h = null_mut();
-    let ok = (_GAPI.vUnWrapPath)(v.as_cptr(), &mut h);
-    if ok == GRAPHIN_RESULT::OK {
-    	(_GAPI.pathAddRef)(h);
-      Some(Path(h))
-    } else {
-      None
-    }
-  }
+	fn from_value(v: &Value) -> Option<Path> {
+		let mut h = null_mut();
+		let ok = (_GAPI.vUnWrapPath)(v.as_cptr(), &mut h);
+		if ok == GRAPHIN_RESULT::OK {
+			(_GAPI.pathAddRef)(h);
+			Some(Path(h))
+		} else {
+			None
+		}
+	}
 }
 
 /// Store the `Path` object as a `Value`.
 impl From<Path> for Value {
-  fn from(i: Path) -> Value {
-    let mut v = Value::new();
-    let ok = (_GAPI.vWrapPath)(i.0, v.as_ptr());
-    assert!(ok == GRAPHIN_RESULT::OK);
-    v
-  }
+	fn from(i: Path) -> Value {
+		let mut v = Value::new();
+		let ok = (_GAPI.vWrapPath)(i.0, v.as_ptr());
+		assert!(ok == GRAPHIN_RESULT::OK);
+		v
+	}
 }
 
 impl Path {
-  /// Create a new empty path.
-  pub fn create() -> Result<Path> {
-    let mut h = null_mut();
-    let ok = (_GAPI.pathCreate)(&mut h);
-    ok_or!(Path(h), ok)
-  }
+	/// Create a new empty path.
+	pub fn create() -> Result<Path> {
+		let mut h = null_mut();
+		let ok = (_GAPI.pathCreate)(&mut h);
+		ok_or!(Path(h), ok)
+	}
 
-  /// Create a new empty path.
-  #[deprecated(note="Use `Path::create()` instead.")]
-  pub fn new() -> Result<Path> {
-  	Self::create()
-  }
+	/// Create a new empty path.
+	#[deprecated(note = "Use `Path::create()` instead.")]
+	pub fn new() -> Result<Path> {
+		Self::create()
+	}
 
-  /// Close the current path/figure.
-  pub fn close(&mut self) -> Result<()> {
-    let ok = (_GAPI.pathClosePath)(self.0);
-    ok_or!((), ok)
-  }
+	/// Close the current path/figure.
+	pub fn close(&mut self) -> Result<()> {
+		let ok = (_GAPI.pathClosePath)(self.0);
+		ok_or!((), ok)
+	}
 
-  /// Move the current drawing path position to `x,y`.
-  ///
-  /// If `is_relative` is `true` then the specified coordinates are interpreted as deltas from the current path position.
-  pub fn move_to(&mut self, point: Pos, is_relative: bool) -> Result<&mut Path> {
-    let ok = (_GAPI.pathMoveTo)(self.0, point.0, point.1, is_relative as BOOL);
-    ok_or!(self, ok)
-  }
+	/// Move the current drawing path position to `x,y`.
+	///
+	/// If `is_relative` is `true` then the specified coordinates are interpreted as deltas from the current path position.
+	pub fn move_to(&mut self, point: Pos, is_relative: bool) -> Result<&mut Path> {
+		let ok = (_GAPI.pathMoveTo)(self.0, point.0, point.1, is_relative as BOOL);
+		ok_or!(self, ok)
+	}
 
-  /// Draw a line and move the current drawing path position to `x,y`.
-  ///
-  /// If `is_relative` is `true` then the specified coordinates are interpreted as deltas from the current path position.
-  pub fn line_to(&mut self, point: Pos, is_relative: bool) -> Result<&mut Path> {
-    let ok = (_GAPI.pathLineTo)(self.0, point.0, point.1, is_relative as BOOL);
-    ok_or!(self, ok)
-  }
+	/// Draw a line and move the current drawing path position to `x,y`.
+	///
+	/// If `is_relative` is `true` then the specified coordinates are interpreted as deltas from the current path position.
+	pub fn line_to(&mut self, point: Pos, is_relative: bool) -> Result<&mut Path> {
+		let ok = (_GAPI.pathLineTo)(self.0, point.0, point.1, is_relative as BOOL);
+		ok_or!(self, ok)
+	}
 
-  /// Draw an arc.
-  pub fn arc_to(&mut self, xy: Pos, angle: Angle, rxy: Pos, is_large: bool, is_clockwise: bool, is_relative: bool) -> Result<&mut Path> {
-    let ok = (_GAPI.pathArcTo)(
-      self.0,
-      xy.0,
-      xy.1,
-      angle,
-      rxy.0,
-      rxy.1,
-      is_large as BOOL,
-      is_clockwise as BOOL,
-      is_relative as BOOL,
-    );
-    ok_or!(self, ok)
-  }
+	/// Draw an arc.
+	pub fn arc_to(&mut self, xy: Pos, angle: Angle, rxy: Pos, is_large: bool, is_clockwise: bool, is_relative: bool) -> Result<&mut Path> {
+		let ok = (_GAPI.pathArcTo)(
+			self.0,
+			xy.0,
+			xy.1,
+			angle,
+			rxy.0,
+			rxy.1,
+			is_large as BOOL,
+			is_clockwise as BOOL,
+			is_relative as BOOL,
+		);
+		ok_or!(self, ok)
+	}
 
-  /// Draw a quadratic Bézier curve.
-  ///
-  /// If `is_relative` is `true` then the specified coordinates are interpreted as deltas from the current path position.
-  pub fn quadratic_curve_to(&mut self, control: Pos, end: Pos, is_relative: bool) -> Result<&mut Path> {
-    let ok = (_GAPI.pathQuadraticCurveTo)(self.0, control.0, control.1, end.0, end.1, is_relative as BOOL);
-    ok_or!(self, ok)
-  }
+	/// Draw a quadratic Bézier curve.
+	///
+	/// If `is_relative` is `true` then the specified coordinates are interpreted as deltas from the current path position.
+	pub fn quadratic_curve_to(&mut self, control: Pos, end: Pos, is_relative: bool) -> Result<&mut Path> {
+		let ok = (_GAPI.pathQuadraticCurveTo)(self.0, control.0, control.1, end.0, end.1, is_relative as BOOL);
+		ok_or!(self, ok)
+	}
 
-  /// Draw a cubic Bézier curve.
-  ///
-  /// If `is_relative` is `true` then the specified coordinates are interpreted as deltas from the current path position.
-  pub fn bezier_curve_to(&mut self, control1: Pos, control2: Pos, end: Pos, is_relative: bool) -> Result<&mut Path> {
-    let ok = (_GAPI.pathBezierCurveTo)(
-      self.0,
-      control1.0,
-      control1.1,
-      control2.0,
-      control2.1,
-      end.0,
-      end.1,
-      is_relative as BOOL,
-    );
-    ok_or!(self, ok)
-  }
+	/// Draw a cubic Bézier curve.
+	///
+	/// If `is_relative` is `true` then the specified coordinates are interpreted as deltas from the current path position.
+	pub fn bezier_curve_to(&mut self, control1: Pos, control2: Pos, end: Pos, is_relative: bool) -> Result<&mut Path> {
+		let ok = (_GAPI.pathBezierCurveTo)(
+			self.0,
+			control1.0,
+			control1.1,
+			control2.0,
+			control2.1,
+			end.0,
+			end.1,
+			is_relative as BOOL,
+		);
+		ok_or!(self, ok)
+	}
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -529,91 +526,91 @@ pub struct Graphics(HGFX);
 
 /// Destroy pointed graphics object.
 impl Drop for Graphics {
-  fn drop(&mut self) {
-    (_GAPI.gRelease)(self.0);
-  }
+	fn drop(&mut self) {
+		(_GAPI.gRelease)(self.0);
+	}
 }
 
 /// Copies graphics object.
 ///
 /// All allocated objects are reference counted so copying is just a matter of increasing reference counts.
 impl Clone for Graphics {
-  fn clone(&self) -> Self {
-    let dst = Graphics(self.0);
-    (_GAPI.gAddRef)(dst.0);
-    dst
-  }
+	fn clone(&self) -> Self {
+		let dst = Graphics(self.0);
+		(_GAPI.gAddRef)(dst.0);
+		dst
+	}
 }
 
 /// Get an `Graphics` object contained in the `Value`.
 impl FromValue for Graphics {
-  fn from_value(v: &Value) -> Option<Graphics> {
-    let mut h = null_mut();
-    let ok = (_GAPI.vUnWrapGfx)(v.as_cptr(), &mut h);
-    if ok == GRAPHIN_RESULT::OK {
-    	(_GAPI.gAddRef)(h);
-      Some(Graphics(h))
-    } else {
-      None
-    }
-  }
+	fn from_value(v: &Value) -> Option<Graphics> {
+		let mut h = null_mut();
+		let ok = (_GAPI.vUnWrapGfx)(v.as_cptr(), &mut h);
+		if ok == GRAPHIN_RESULT::OK {
+			(_GAPI.gAddRef)(h);
+			Some(Graphics(h))
+		} else {
+			None
+		}
+	}
 }
 
 /// Store the `Graphics` object as a `Value`.
 impl From<Graphics> for Value {
-  fn from(i: Graphics) -> Value {
-    let mut v = Value::new();
-    let ok = (_GAPI.vWrapGfx)(i.0, v.as_ptr());
-    assert!(ok == GRAPHIN_RESULT::OK);
-    v
-  }
+	fn from(i: Graphics) -> Value {
+		let mut v = Value::new();
+		let ok = (_GAPI.vWrapGfx)(i.0, v.as_ptr());
+		assert!(ok == GRAPHIN_RESULT::OK);
+		v
+	}
 }
 
 /// Construct Graphics object from `HGFX` handle.
 impl From<HGFX> for Graphics {
 	fn from(hgfx: HGFX) -> Graphics {
 		assert!(!hgfx.is_null());
-  	(_GAPI.gAddRef)(hgfx);
+		(_GAPI.gAddRef)(hgfx);
 		Graphics(hgfx)
 	}
 }
 
 /// Save/restore graphics state.
 impl Graphics {
-  /// Save the current graphics attributes on top of the internal state stack.
-  ///
-  /// It will be restored automatically.
-  ///
-  /// # Example:
-  ///
-  /// ```rust
-  /// use sciter::graphics::{Image, rgb};
-  ///
-  /// let mut image = Image::new((100, 100), false).unwrap();
-  /// image.paint(|gfx, size| {
-  ///   let mut gfx = gfx.save_state()?;
-  ///   gfx
-  ///     .line_width(6.0)?
-  ///     .line_color(rgb(0xD4, 0, 0))?
-  ///     .fill_color(rgb(0xD4, 0, 0))?
-  ///     .line((-30., 0.), (83., 0.))?
-  ///     ;
-  ///   Ok(())
-  /// }).unwrap();
-	pub fn save_state(&mut self) -> Result<State> {
+	/// Save the current graphics attributes on top of the internal state stack.
+	///
+	/// It will be restored automatically.
+	///
+	/// # Example:
+	///
+	/// ```rust
+	/// use sciter::graphics::{Image, rgb};
+	///
+	/// let mut image = Image::new((100, 100), false).unwrap();
+	/// image.paint(|gfx, size| {
+	///   let mut gfx = gfx.save_state()?;
+	///   gfx
+	///     .line_width(6.0)?
+	///     .line_color(rgb(0xD4, 0, 0))?
+	///     .fill_color(rgb(0xD4, 0, 0))?
+	///     .line((-30., 0.), (83., 0.))?
+	///     ;
+	///   Ok(())
+	/// }).unwrap();
+	pub fn save_state(&mut self) -> Result<State<'_>> {
 		self.push_state().map(|gfx| State(gfx))
 	}
 
-  /// Manually save the current graphics attributes on top of the internal state stack.
-  fn push_state(&mut self) -> Result<&mut Self> {
-    let ok = (_GAPI.gStateSave)(self.0);
-    ok_or!(self, ok)
-  }
+	/// Manually save the current graphics attributes on top of the internal state stack.
+	fn push_state(&mut self) -> Result<&mut Self> {
+		let ok = (_GAPI.gStateSave)(self.0);
+		ok_or!(self, ok)
+	}
 
-  /// Manually restore graphics attributes from top of the internal state stack.
-  fn pop_state(&mut self) -> Result<&mut Self> {
-    let ok = (_GAPI.gStateRestore)(self.0);
-    ok_or!(self, ok)
+	/// Manually restore graphics attributes from top of the internal state stack.
+	fn pop_state(&mut self) -> Result<&mut Self> {
+		let ok = (_GAPI.gStateRestore)(self.0);
+		ok_or!(self, ok)
 	}
 
 	/// Flush all pending graphic operations.
@@ -627,375 +624,375 @@ impl Graphics {
 ///
 /// All operations use the current fill and stroke brushes.
 impl Graphics {
-  /// Draw a line from the `start` to the `end`.
-  pub fn line(&mut self, start: Pos, end: Pos) -> Result<&mut Self> {
-    let ok = (_GAPI.gLine)(self.0, start.0, start.1, end.0, end.1);
-    ok_or!(self, ok)
-  }
+	/// Draw a line from the `start` to the `end`.
+	pub fn line(&mut self, start: Pos, end: Pos) -> Result<&mut Self> {
+		let ok = (_GAPI.gLine)(self.0, start.0, start.1, end.0, end.1);
+		ok_or!(self, ok)
+	}
 
-  /// Draw a rectangle.
-  pub fn rectangle(&mut self, left_top: Pos, right_bottom: Pos) -> Result<&mut Self> {
-    let ok = (_GAPI.gRectangle)(self.0, left_top.0, left_top.1, right_bottom.0, right_bottom.1);
-    ok_or!(self, ok)
-  }
+	/// Draw a rectangle.
+	pub fn rectangle(&mut self, left_top: Pos, right_bottom: Pos) -> Result<&mut Self> {
+		let ok = (_GAPI.gRectangle)(self.0, left_top.0, left_top.1, right_bottom.0, right_bottom.1);
+		ok_or!(self, ok)
+	}
 
-  /// Draw a rounded rectangle with the same corners.
-  pub fn round_rect(&mut self, left_top: Pos, right_bottom: Pos, radius: Dim) -> Result<&mut Self> {
-    let rad: [Dim; 8] = [radius; 8usize];
-    let ok = (_GAPI.gRoundedRectangle)(self.0, left_top.0, left_top.1, right_bottom.0, right_bottom.1, rad.as_ptr());
-    ok_or!(self, ok)
-  }
+	/// Draw a rounded rectangle with the same corners.
+	pub fn round_rect(&mut self, left_top: Pos, right_bottom: Pos, radius: Dim) -> Result<&mut Self> {
+		let rad: [Dim; 8] = [radius; 8usize];
+		let ok = (_GAPI.gRoundedRectangle)(self.0, left_top.0, left_top.1, right_bottom.0, right_bottom.1, rad.as_ptr());
+		ok_or!(self, ok)
+	}
 
-  /// Draw a rounded rectangle with different corners.
-  pub fn round_rect4(&mut self, left_top: Pos, right_bottom: Pos, radius: (Dim, Dim, Dim, Dim)) -> Result<&mut Self> {
-    let r = radius;
-    let rad: [Dim; 8] = [r.0, r.0, r.1, r.1, r.2, r.2, r.3, r.3];
-    let ok = (_GAPI.gRoundedRectangle)(self.0, left_top.0, left_top.1, right_bottom.0, right_bottom.1, rad.as_ptr());
-    ok_or!(self, ok)
-  }
+	/// Draw a rounded rectangle with different corners.
+	pub fn round_rect4(&mut self, left_top: Pos, right_bottom: Pos, radius: (Dim, Dim, Dim, Dim)) -> Result<&mut Self> {
+		let r = radius;
+		let rad: [Dim; 8] = [r.0, r.0, r.1, r.1, r.2, r.2, r.3, r.3];
+		let ok = (_GAPI.gRoundedRectangle)(self.0, left_top.0, left_top.1, right_bottom.0, right_bottom.1, rad.as_ptr());
+		ok_or!(self, ok)
+	}
 
-  /// Draw an ellipse.
-  pub fn ellipse(&mut self, xy: Pos, radii: Pos) -> Result<&mut Self> {
-    let ok = (_GAPI.gEllipse)(self.0, xy.0, xy.1, radii.0, radii.1);
-    ok_or!(self, ok)
-  }
+	/// Draw an ellipse.
+	pub fn ellipse(&mut self, xy: Pos, radii: Pos) -> Result<&mut Self> {
+		let ok = (_GAPI.gEllipse)(self.0, xy.0, xy.1, radii.0, radii.1);
+		ok_or!(self, ok)
+	}
 
-  /// Draw a circle.
-  pub fn circle(&mut self, xy: Pos, radius: Dim) -> Result<&mut Self> {
-    let ok = (_GAPI.gEllipse)(self.0, xy.0, xy.1, radius, radius);
-    ok_or!(self, ok)
-  }
+	/// Draw a circle.
+	pub fn circle(&mut self, xy: Pos, radius: Dim) -> Result<&mut Self> {
+		let ok = (_GAPI.gEllipse)(self.0, xy.0, xy.1, radius, radius);
+		ok_or!(self, ok)
+	}
 
-  /// Draw a closed arc.
-  pub fn arc(&mut self, xy: Pos, rxy: Pos, start: Angle, sweep: Angle) -> Result<&mut Self> {
-    let ok = (_GAPI.gArc)(self.0, xy.0, xy.1, rxy.0, rxy.1, start, sweep);
-    ok_or!(self, ok)
-  }
+	/// Draw a closed arc.
+	pub fn arc(&mut self, xy: Pos, rxy: Pos, start: Angle, sweep: Angle) -> Result<&mut Self> {
+		let ok = (_GAPI.gArc)(self.0, xy.0, xy.1, rxy.0, rxy.1, start, sweep);
+		ok_or!(self, ok)
+	}
 
-  /// Draw a star.
-  pub fn star(&mut self, xy: Pos, r1: Dim, r2: Dim, start: Angle, rays: usize) -> Result<&mut Self> {
-    let ok = (_GAPI.gStar)(self.0, xy.0, xy.1, r1, r2, start, rays as UINT);
-    ok_or!(self, ok)
-  }
+	/// Draw a star.
+	pub fn star(&mut self, xy: Pos, r1: Dim, r2: Dim, start: Angle, rays: usize) -> Result<&mut Self> {
+		let ok = (_GAPI.gStar)(self.0, xy.0, xy.1, r1, r2, start, rays as UINT);
+		ok_or!(self, ok)
+	}
 
-  /// Draw a closed polygon.
-  pub fn polygon(&mut self, points: &[Pos]) -> Result<&mut Self> {
-    // A compile time assert (credits to https://github.com/nvzqz/static-assertions-rs)
-    type PosArray = [Pos; 2];
-    type FloatArray = [SC_POS; 4];
-    let _ = ::std::mem::transmute::<FloatArray, PosArray>;
+	/// Draw a closed polygon.
+	pub fn polygon(&mut self, points: &[Pos]) -> Result<&mut Self> {
+		// A compile time assert (credits to https://github.com/nvzqz/static-assertions-rs)
+		type PosArray = [Pos; 2];
+		type FloatArray = [SC_POS; 4];
+		let _ = ::std::mem::transmute::<FloatArray, PosArray>;
 
-    let ok = (_GAPI.gPolygon)(self.0, points.as_ptr() as *const SC_POS, points.len() as UINT);
-    ok_or!(self, ok)
-  }
+		let ok = (_GAPI.gPolygon)(self.0, points.as_ptr() as *const SC_POS, points.len() as UINT);
+		ok_or!(self, ok)
+	}
 
-  /// Draw a polyline.
-  pub fn polyline(&mut self, points: &[Pos]) -> Result<&mut Self> {
-    // A compile time assert (credits to https://github.com/nvzqz/static-assertions-rs)
-    type PosArray = [Pos; 2];
-    type FloatArray = [SC_POS; 4];
-    let _ = ::std::mem::transmute::<FloatArray, PosArray>;
+	/// Draw a polyline.
+	pub fn polyline(&mut self, points: &[Pos]) -> Result<&mut Self> {
+		// A compile time assert (credits to https://github.com/nvzqz/static-assertions-rs)
+		type PosArray = [Pos; 2];
+		type FloatArray = [SC_POS; 4];
+		let _ = ::std::mem::transmute::<FloatArray, PosArray>;
 
-    let ok = (_GAPI.gPolyline)(self.0, points.as_ptr() as *const SC_POS, points.len() as UINT);
-    ok_or!(self, ok)
-  }
+		let ok = (_GAPI.gPolyline)(self.0, points.as_ptr() as *const SC_POS, points.len() as UINT);
+		ok_or!(self, ok)
+	}
 }
 
 /// Drawing attributes.
 impl Graphics {
 	const NO_COLOR: Color = 0;
 
-  /// Set the color for solid fills for subsequent drawings.
-  pub fn fill_color(&mut self, color: Color) -> Result<&mut Self> {
-    let ok = (_GAPI.gFillColor)(self.0, color);
-    ok_or!(self, ok)
-  }
+	/// Set the color for solid fills for subsequent drawings.
+	pub fn fill_color(&mut self, color: Color) -> Result<&mut Self> {
+		let ok = (_GAPI.gFillColor)(self.0, color);
+		ok_or!(self, ok)
+	}
 
-  /// Set the even/odd rule of solid fills for subsequent drawings.
-  ///
-  /// `false` means "fill non zero".
-  pub fn fill_mode(&mut self, is_even: bool) -> Result<&mut Self> {
-    let ok = (_GAPI.gFillMode)(self.0, is_even as BOOL);
-    ok_or!(self, ok)
-  }
+	/// Set the even/odd rule of solid fills for subsequent drawings.
+	///
+	/// `false` means "fill non zero".
+	pub fn fill_mode(&mut self, is_even: bool) -> Result<&mut Self> {
+		let ok = (_GAPI.gFillMode)(self.0, is_even as BOOL);
+		ok_or!(self, ok)
+	}
 
-  /// Disables fills for subsequent drawing operations.
-  pub fn no_fill(&mut self) -> Result<&mut Self> {
-    self.fill_color(Self::NO_COLOR)
-  }
+	/// Disables fills for subsequent drawing operations.
+	pub fn no_fill(&mut self) -> Result<&mut Self> {
+		self.fill_color(Self::NO_COLOR)
+	}
 
-  /// Set the line color for subsequent drawings.
-  pub fn line_color(&mut self, color: Color) -> Result<&mut Self> {
-    let ok = (_GAPI.gLineColor)(self.0, color);
-    ok_or!(self, ok)
-  }
+	/// Set the line color for subsequent drawings.
+	pub fn line_color(&mut self, color: Color) -> Result<&mut Self> {
+		let ok = (_GAPI.gLineColor)(self.0, color);
+		ok_or!(self, ok)
+	}
 
-  /// Set the line width for subsequent drawings.
-  pub fn line_width(&mut self, width: Dim) -> Result<&mut Self> {
-    let ok = (_GAPI.gLineWidth)(self.0, width);
-    ok_or!(self, ok)
-  }
+	/// Set the line width for subsequent drawings.
+	pub fn line_width(&mut self, width: Dim) -> Result<&mut Self> {
+		let ok = (_GAPI.gLineWidth)(self.0, width);
+		ok_or!(self, ok)
+	}
 
-  /// Set the line cap mode (stroke dash ending style) for subsequent drawings.
-  ///
-  /// It determines how the end points of every line are drawn.
-  /// There are three possible values for this property and those are: `BUTT`, `ROUND` and `SQUARE`.
-  /// By default this property is set to `BUTT`.
-  pub fn line_cap(&mut self, style: LINE_CAP) -> Result<&mut Self> {
-    let ok = (_GAPI.gLineCap)(self.0, style);
-    ok_or!(self, ok)
-  }
+	/// Set the line cap mode (stroke dash ending style) for subsequent drawings.
+	///
+	/// It determines how the end points of every line are drawn.
+	/// There are three possible values for this property and those are: `BUTT`, `ROUND` and `SQUARE`.
+	/// By default this property is set to `BUTT`.
+	pub fn line_cap(&mut self, style: LINE_CAP) -> Result<&mut Self> {
+		let ok = (_GAPI.gLineCap)(self.0, style);
+		ok_or!(self, ok)
+	}
 
-  /// Set the line join mode for subsequent drawings.
-  ///
-  /// It determines how two connecting segments (of lines, arcs or curves)
-  /// with non-zero lengths in a shape are joined together
-  /// (degenerate segments with zero lengths, whose specified endpoints and control points
-  /// are exactly at the same position, are skipped).
-  pub fn line_join(&mut self, style: LINE_JOIN) -> Result<&mut Self> {
-    let ok = (_GAPI.gLineJoin)(self.0, style);
-    ok_or!(self, ok)
-  }
+	/// Set the line join mode for subsequent drawings.
+	///
+	/// It determines how two connecting segments (of lines, arcs or curves)
+	/// with non-zero lengths in a shape are joined together
+	/// (degenerate segments with zero lengths, whose specified endpoints and control points
+	/// are exactly at the same position, are skipped).
+	pub fn line_join(&mut self, style: LINE_JOIN) -> Result<&mut Self> {
+		let ok = (_GAPI.gLineJoin)(self.0, style);
+		ok_or!(self, ok)
+	}
 
-  /// Disable outline drawing.
-  pub fn no_line(&mut self) -> Result<&mut Self> {
-    self.line_width(0.0)
-  }
+	/// Disable outline drawing.
+	pub fn no_line(&mut self) -> Result<&mut Self> {
+		self.line_width(0.0)
+	}
 
-  /// Setup parameters of a linear gradient of lines.
-  pub fn line_linear_gradient(&mut self, start: Pos, end: Pos, c1: Color, c2: Color) -> Result<&mut Self> {
-    let stops = [(c1, 0.0), (c2, 1.0)];
-    self.line_linear_gradients(start, end, &stops)
-  }
+	/// Setup parameters of a linear gradient of lines.
+	pub fn line_linear_gradient(&mut self, start: Pos, end: Pos, c1: Color, c2: Color) -> Result<&mut Self> {
+		let stops = [(c1, 0.0), (c2, 1.0)];
+		self.line_linear_gradients(start, end, &stops)
+	}
 
-  /// Setup parameters of a linear gradient of lines using multiple colors and color stop positions `(0.0 ... 1.0)`.
-  pub fn line_linear_gradients(&mut self, start: Pos, end: Pos, colors: &[(Color, Dim)]) -> Result<&mut Self> {
-    let _ = ::std::mem::transmute::<SC_COLOR_STOP, (Color, Dim)>;
-    let ok = (_GAPI.gLineGradientLinear)(
-      self.0,
-      start.0,
-      start.1,
-      end.0,
-      end.1,
-      colors.as_ptr() as *const SC_COLOR_STOP,
-      colors.len() as UINT,
-    );
-    ok_or!(self, ok)
-  }
+	/// Setup parameters of a linear gradient of lines using multiple colors and color stop positions `(0.0 ... 1.0)`.
+	pub fn line_linear_gradients(&mut self, start: Pos, end: Pos, colors: &[(Color, Dim)]) -> Result<&mut Self> {
+		let _ = ::std::mem::transmute::<SC_COLOR_STOP, (Color, Dim)>;
+		let ok = (_GAPI.gLineGradientLinear)(
+			self.0,
+			start.0,
+			start.1,
+			end.0,
+			end.1,
+			colors.as_ptr() as *const SC_COLOR_STOP,
+			colors.len() as UINT,
+		);
+		ok_or!(self, ok)
+	}
 
-  /// Setup parameters of linear gradient fills.
-  pub fn fill_linear_gradient(&mut self, c1: Color, c2: Color, start: Pos, end: Pos) -> Result<&mut Self> {
-    let stops = [(c1, 0.0), (c2, 1.0)];
-    self.fill_linear_gradients(&stops, start, end)
-  }
+	/// Setup parameters of linear gradient fills.
+	pub fn fill_linear_gradient(&mut self, c1: Color, c2: Color, start: Pos, end: Pos) -> Result<&mut Self> {
+		let stops = [(c1, 0.0), (c2, 1.0)];
+		self.fill_linear_gradients(&stops, start, end)
+	}
 
-  /// Setup parameters of linear gradient fills using multiple colors and color stop positions `(0.0 ... 1.0)`.
-  pub fn fill_linear_gradients(&mut self, colors: &[(Color, Dim)], start: Pos, end: Pos) -> Result<&mut Self> {
-    let _ = ::std::mem::transmute::<SC_COLOR_STOP, (Color, Dim)>;
-    let ok = (_GAPI.gFillGradientLinear)(
-      self.0,
-      start.0,
-      start.1,
-      end.0,
-      end.1,
-      colors.as_ptr() as *const SC_COLOR_STOP,
-      colors.len() as UINT,
-    );
-    ok_or!(self, ok)
-  }
+	/// Setup parameters of linear gradient fills using multiple colors and color stop positions `(0.0 ... 1.0)`.
+	pub fn fill_linear_gradients(&mut self, colors: &[(Color, Dim)], start: Pos, end: Pos) -> Result<&mut Self> {
+		let _ = ::std::mem::transmute::<SC_COLOR_STOP, (Color, Dim)>;
+		let ok = (_GAPI.gFillGradientLinear)(
+			self.0,
+			start.0,
+			start.1,
+			end.0,
+			end.1,
+			colors.as_ptr() as *const SC_COLOR_STOP,
+			colors.len() as UINT,
+		);
+		ok_or!(self, ok)
+	}
 
-  /// Setup parameters of a radial gradient of lines.
-  pub fn line_radial_gradient(&mut self, point: Pos, radii: (Dim, Dim), c1: Color, c2: Color) -> Result<&mut Self> {
-    let stops = [(c1, 0.0), (c2, 1.0)];
-    self.line_radial_gradients(point, radii, &stops)
-  }
+	/// Setup parameters of a radial gradient of lines.
+	pub fn line_radial_gradient(&mut self, point: Pos, radii: (Dim, Dim), c1: Color, c2: Color) -> Result<&mut Self> {
+		let stops = [(c1, 0.0), (c2, 1.0)];
+		self.line_radial_gradients(point, radii, &stops)
+	}
 
-  /// Setup parameters of a radial gradient of lines using multiple colors and color stop positions `(0.0 ... 1.0)`.
-  pub fn line_radial_gradients(&mut self, point: Pos, radii: (Dim, Dim), colors: &[(Color, Dim)]) -> Result<&mut Self> {
-    let _ = ::std::mem::transmute::<SC_COLOR_STOP, (Color, Dim)>;
-    let ok = (_GAPI.gLineGradientRadial)(
-      self.0,
-      point.0,
-      point.1,
-      radii.0,
-      radii.1,
-      colors.as_ptr() as *const SC_COLOR_STOP,
-      colors.len() as UINT,
-    );
-    ok_or!(self, ok)
-  }
+	/// Setup parameters of a radial gradient of lines using multiple colors and color stop positions `(0.0 ... 1.0)`.
+	pub fn line_radial_gradients(&mut self, point: Pos, radii: (Dim, Dim), colors: &[(Color, Dim)]) -> Result<&mut Self> {
+		let _ = ::std::mem::transmute::<SC_COLOR_STOP, (Color, Dim)>;
+		let ok = (_GAPI.gLineGradientRadial)(
+			self.0,
+			point.0,
+			point.1,
+			radii.0,
+			radii.1,
+			colors.as_ptr() as *const SC_COLOR_STOP,
+			colors.len() as UINT,
+		);
+		ok_or!(self, ok)
+	}
 
-  /// Setup parameters of radial gradient of fills.
-  pub fn fill_radial_gradient(&mut self, c1: Color, c2: Color, point: Pos, radii: (Dim, Dim)) -> Result<&mut Self> {
-    let stops = [(c1, 0.0), (c2, 1.0)];
-    self.fill_radial_gradients(&stops, point, radii)
-  }
+	/// Setup parameters of radial gradient of fills.
+	pub fn fill_radial_gradient(&mut self, c1: Color, c2: Color, point: Pos, radii: (Dim, Dim)) -> Result<&mut Self> {
+		let stops = [(c1, 0.0), (c2, 1.0)];
+		self.fill_radial_gradients(&stops, point, radii)
+	}
 
-  /// Setup parameters of radial gradient of fills using multiple colors and color stop positions `(0.0 ... 1.0)`.
-  pub fn fill_radial_gradients(&mut self, colors: &[(Color, Dim)], point: Pos, radii: (Dim, Dim)) -> Result<&mut Self> {
-    let _ = ::std::mem::transmute::<SC_COLOR_STOP, (Color, Dim)>;
-    let ok = (_GAPI.gFillGradientRadial)(
-      self.0,
-      point.0,
-      point.1,
-      radii.0,
-      radii.1,
-      colors.as_ptr() as *const SC_COLOR_STOP,
-      colors.len() as UINT,
-    );
-    ok_or!(self, ok)
-  }
+	/// Setup parameters of radial gradient of fills using multiple colors and color stop positions `(0.0 ... 1.0)`.
+	pub fn fill_radial_gradients(&mut self, colors: &[(Color, Dim)], point: Pos, radii: (Dim, Dim)) -> Result<&mut Self> {
+		let _ = ::std::mem::transmute::<SC_COLOR_STOP, (Color, Dim)>;
+		let ok = (_GAPI.gFillGradientRadial)(
+			self.0,
+			point.0,
+			point.1,
+			radii.0,
+			radii.1,
+			colors.as_ptr() as *const SC_COLOR_STOP,
+			colors.len() as UINT,
+		);
+		ok_or!(self, ok)
+	}
 }
 
 /// Affine transformations.
 impl Graphics {
-  /// Rotate coordinate system on `radians` angle.
-  pub fn rotate(&mut self, radians: Angle) -> Result<&mut Self> {
-    let ok = (_GAPI.gRotate)(self.0, radians, None, None);
-    ok_or!(self, ok)
-  }
+	/// Rotate coordinate system on `radians` angle.
+	pub fn rotate(&mut self, radians: Angle) -> Result<&mut Self> {
+		let ok = (_GAPI.gRotate)(self.0, radians, None, None);
+		ok_or!(self, ok)
+	}
 
-  /// Rotate coordinate system on `radians` angle around the `center`.
-  pub fn rotate_around(&mut self, radians: Angle, center: Pos) -> Result<&mut Self> {
-    let ok = (_GAPI.gRotate)(self.0, radians, Some(&center.0), Some(&center.1));
-    ok_or!(self, ok)
-  }
+	/// Rotate coordinate system on `radians` angle around the `center`.
+	pub fn rotate_around(&mut self, radians: Angle, center: Pos) -> Result<&mut Self> {
+		let ok = (_GAPI.gRotate)(self.0, radians, Some(&center.0), Some(&center.1));
+		ok_or!(self, ok)
+	}
 
-  /// Move origin of coordinate system to the `(to_x, to_y)` point.
-  pub fn translate(&mut self, to_xy: Pos) -> Result<&mut Self> {
-    let ok = (_GAPI.gTranslate)(self.0, to_xy.0, to_xy.1);
-    ok_or!(self, ok)
-  }
+	/// Move origin of coordinate system to the `(to_x, to_y)` point.
+	pub fn translate(&mut self, to_xy: Pos) -> Result<&mut Self> {
+		let ok = (_GAPI.gTranslate)(self.0, to_xy.0, to_xy.1);
+		ok_or!(self, ok)
+	}
 
-  /// Scale coordinate system.
-  ///
-  /// `(sc_x, sc_y)` are the scale factors in the horizontal and vertical directions respectively.
-  ///
-  /// Both parameters must be positive numbers.
-  /// Values smaller than `1.0` reduce the unit size and values larger than `1.0` increase the unit size.
-  pub fn scale(&mut self, sc_xy: Pos) -> Result<&mut Self> {
-    let ok = (_GAPI.gScale)(self.0, sc_xy.0, sc_xy.1);
-    ok_or!(self, ok)
-  }
+	/// Scale coordinate system.
+	///
+	/// `(sc_x, sc_y)` are the scale factors in the horizontal and vertical directions respectively.
+	///
+	/// Both parameters must be positive numbers.
+	/// Values smaller than `1.0` reduce the unit size and values larger than `1.0` increase the unit size.
+	pub fn scale(&mut self, sc_xy: Pos) -> Result<&mut Self> {
+		let ok = (_GAPI.gScale)(self.0, sc_xy.0, sc_xy.1);
+		ok_or!(self, ok)
+	}
 
-  /// Setup a skewing (shearing) transformation.
-  pub fn skew(&mut self, sh_xy: Pos) -> Result<&mut Self> {
-    let ok = (_GAPI.gSkew)(self.0, sh_xy.0, sh_xy.1);
-    ok_or!(self, ok)
-  }
+	/// Setup a skewing (shearing) transformation.
+	pub fn skew(&mut self, sh_xy: Pos) -> Result<&mut Self> {
+		let ok = (_GAPI.gSkew)(self.0, sh_xy.0, sh_xy.1);
+		ok_or!(self, ok)
+	}
 
-  /// Multiply the current transformation with the matrix described by the arguments.
-  ///
-  /// It allows to scale, rotate, move and skew the context
-  /// as described by:
-  ///
-  /// ```text
-  ///    scale_x  skew_y   move_x
-  /// [  skew_x   scale_y  move_y  ]
-  ///    0        0        1
-  /// ```
-  ///
-  /// where
-  ///
-  /// * `scale_x`, `scale_y`: horizontal and vertical scaling,
-  /// * `skew_x`, `skew_y`:   horizontal and vertical shearing (skewing),
-  /// * `move_x`, `move_y`:   horizontal and vertical moving.
-  ///
-  pub fn transform(&mut self, scale_by: Pos, skew_by: Pos, move_to: Pos) -> Result<&mut Self> {
-    // m11, m12, m21, m22, dx, dy
-    // scx, shx, shy, scy, dx, dy
-    let ok = (_GAPI.gTransform)(self.0, scale_by.0, skew_by.0, skew_by.1, scale_by.0, move_to.0, move_to.1);
-    ok_or!(self, ok)
-  }
+	/// Multiply the current transformation with the matrix described by the arguments.
+	///
+	/// It allows to scale, rotate, move and skew the context
+	/// as described by:
+	///
+	/// ```text
+	///    scale_x  skew_y   move_x
+	/// [  skew_x   scale_y  move_y  ]
+	///    0        0        1
+	/// ```
+	///
+	/// where
+	///
+	/// * `scale_x`, `scale_y`: horizontal and vertical scaling,
+	/// * `skew_x`, `skew_y`:   horizontal and vertical shearing (skewing),
+	/// * `move_x`, `move_y`:   horizontal and vertical moving.
+	///
+	pub fn transform(&mut self, scale_by: Pos, skew_by: Pos, move_to: Pos) -> Result<&mut Self> {
+		// m11, m12, m21, m22, dx, dy
+		// scx, shx, shy, scy, dx, dy
+		let ok = (_GAPI.gTransform)(self.0, scale_by.0, skew_by.0, skew_by.1, scale_by.0, move_to.0, move_to.1);
+		ok_or!(self, ok)
+	}
 
-  /// Multiply the current transformation with the matrix described by the arguments.
-  ///
-  /// It allows to scale, rotate, move and skew the context
-  /// as described by:
-  ///
-  /// ```text
-  ///    m11   m21  dx
-  /// [  m12   m22  dy  ]
-  ///    0     0    1
-  /// ```
-  ///
-  /// * `m11` (`scale_x`): horizontal scaling
-  /// * `m12` (`skew_x`):  horizontal skewing
-  /// * `m21` (`skew_y`):  vertical skewing
-  /// * `m22` (`scale_y`): vertical scaling
-  /// * `dx`  (`move_x`):  horizontal moving
-  /// * `dy`  (`move_y`):  vertical moving
-  ///
-  pub fn transform_matrix(&mut self, m11: Dim, m12: Dim, m21: Dim, m22: Dim, dx: Dim, dy: Dim) -> Result<&mut Self> {
-    self.transform((m11, m22), (m12, m21), (dx, dy))
-  }
+	/// Multiply the current transformation with the matrix described by the arguments.
+	///
+	/// It allows to scale, rotate, move and skew the context
+	/// as described by:
+	///
+	/// ```text
+	///    m11   m21  dx
+	/// [  m12   m22  dy  ]
+	///    0     0    1
+	/// ```
+	///
+	/// * `m11` (`scale_x`): horizontal scaling
+	/// * `m12` (`skew_x`):  horizontal skewing
+	/// * `m21` (`skew_y`):  vertical skewing
+	/// * `m22` (`scale_y`): vertical scaling
+	/// * `dx`  (`move_x`):  horizontal moving
+	/// * `dy`  (`move_y`):  vertical moving
+	///
+	pub fn transform_matrix(&mut self, m11: Dim, m12: Dim, m21: Dim, m22: Dim, dx: Dim, dy: Dim) -> Result<&mut Self> {
+		self.transform((m11, m22), (m12, m21), (dx, dy))
+	}
 }
 
 /// Coordinate space.
 impl Graphics {
-  /// Translate coordinates.
-  ///
-  /// Translates coordinates from a coordinate system defined by `rotate()`, `scale()`, `translate()` and/or `skew()`
-  /// to the screen coordinate system.
-  pub fn world_to_screen(&self, mut xy: Pos) -> Result<Pos> {
-    let ok = (_GAPI.gWorldToScreen)(self.0, &mut xy.0, &mut xy.1);
-    ok_or!(xy, ok)
-  }
+	/// Translate coordinates.
+	///
+	/// Translates coordinates from a coordinate system defined by `rotate()`, `scale()`, `translate()` and/or `skew()`
+	/// to the screen coordinate system.
+	pub fn world_to_screen(&self, mut xy: Pos) -> Result<Pos> {
+		let ok = (_GAPI.gWorldToScreen)(self.0, &mut xy.0, &mut xy.1);
+		ok_or!(xy, ok)
+	}
 
-  /// Translate coordinates.
-  ///
-  /// Translates coordinates from a coordinate system defined by `rotate()`, `scale()`, `translate()` and/or `skew()`
-  /// to the screen coordinate system.
-  pub fn world_to_screen1(&self, mut length: Dim) -> Result<Dim> {
-    let mut dummy = 0.0;
-    let ok = (_GAPI.gWorldToScreen)(self.0, &mut length, &mut dummy);
-    ok_or!(length, ok)
-  }
+	/// Translate coordinates.
+	///
+	/// Translates coordinates from a coordinate system defined by `rotate()`, `scale()`, `translate()` and/or `skew()`
+	/// to the screen coordinate system.
+	pub fn world_to_screen1(&self, mut length: Dim) -> Result<Dim> {
+		let mut dummy = 0.0;
+		let ok = (_GAPI.gWorldToScreen)(self.0, &mut length, &mut dummy);
+		ok_or!(length, ok)
+	}
 
-  /// Translate coordinates.
-  ///
-  /// Translates coordinates from screen coordinate system to the one defined by `rotate()`, `scale()`, `translate()` and/or `skew()`.
-  pub fn screen_to_world(&self, mut xy: Pos) -> Result<Pos> {
-    let ok = (_GAPI.gScreenToWorld)(self.0, &mut xy.0, &mut xy.1);
-    ok_or!(xy, ok)
-  }
+	/// Translate coordinates.
+	///
+	/// Translates coordinates from screen coordinate system to the one defined by `rotate()`, `scale()`, `translate()` and/or `skew()`.
+	pub fn screen_to_world(&self, mut xy: Pos) -> Result<Pos> {
+		let ok = (_GAPI.gScreenToWorld)(self.0, &mut xy.0, &mut xy.1);
+		ok_or!(xy, ok)
+	}
 
-  /// Translate coordinates.
-  ///
-  /// Translates coordinates from screen coordinate system to the one defined by `rotate()`, `scale()`, `translate()` and/or `skew()`.
-  pub fn screen_to_world1(&self, mut length: Dim) -> Result<Dim> {
-    let mut dummy = 0.0;
-    let ok = (_GAPI.gScreenToWorld)(self.0, &mut length, &mut dummy);
-    ok_or!(length, ok)
-  }
+	/// Translate coordinates.
+	///
+	/// Translates coordinates from screen coordinate system to the one defined by `rotate()`, `scale()`, `translate()` and/or `skew()`.
+	pub fn screen_to_world1(&self, mut length: Dim) -> Result<Dim> {
+		let mut dummy = 0.0;
+		let ok = (_GAPI.gScreenToWorld)(self.0, &mut length, &mut dummy);
+		ok_or!(length, ok)
+	}
 }
 
 /// Clipping.
 impl Graphics {
-  /// Push a clip layer defined by the specified rectangle bounds.
-  pub fn push_clip_box(&mut self, left_top: Pos, right_bottom: Pos, opacity: Option<f32>) -> Result<&mut Self> {
-    let ok = (_GAPI.gPushClipBox)(
-      self.0,
-      left_top.0,
-      left_top.1,
-      right_bottom.0,
-      right_bottom.1,
-      opacity.unwrap_or(1.0),
-    );
-    ok_or!(self, ok)
-  }
+	/// Push a clip layer defined by the specified rectangle bounds.
+	pub fn push_clip_box(&mut self, left_top: Pos, right_bottom: Pos, opacity: Option<f32>) -> Result<&mut Self> {
+		let ok = (_GAPI.gPushClipBox)(
+			self.0,
+			left_top.0,
+			left_top.1,
+			right_bottom.0,
+			right_bottom.1,
+			opacity.unwrap_or(1.0),
+		);
+		ok_or!(self, ok)
+	}
 
-  /// Push a clip layer defined by the specified `path` bounds.
-  pub fn push_clip_path(&mut self, path: &Path, opacity: Option<f32>) -> Result<&mut Self> {
-    let ok = (_GAPI.gPushClipPath)(self.0, path.0, opacity.unwrap_or(1.0));
-    ok_or!(self, ok)
-  }
+	/// Push a clip layer defined by the specified `path` bounds.
+	pub fn push_clip_path(&mut self, path: &Path, opacity: Option<f32>) -> Result<&mut Self> {
+		let ok = (_GAPI.gPushClipPath)(self.0, path.0, opacity.unwrap_or(1.0));
+		ok_or!(self, ok)
+	}
 
-  /// Pop a clip layer set by previous `push_clip_box()` or `push_clip_path()` calls.
-  pub fn pop_clip(&mut self) -> Result<&mut Self> {
-    let ok = (_GAPI.gPopClip)(self.0);
-    ok_or!(self, ok)
-  }
+	/// Pop a clip layer set by previous `push_clip_box()` or `push_clip_path()` calls.
+	pub fn pop_clip(&mut self) -> Result<&mut Self> {
+		let ok = (_GAPI.gPopClip)(self.0);
+		ok_or!(self, ok)
+	}
 }
 
 /// Image and path rendering.
@@ -1011,93 +1008,93 @@ impl Graphics {
 		ok_or!(self, ok)
 	}
 
-  /// Draw the path object using current fill and stroke brushes.
-  pub fn draw_path(&mut self, path: &Path, mode: DRAW_PATH) -> Result<&mut Self> {
-    let ok = (_GAPI.gDrawPath)(self.0, path.0, mode);
-    ok_or!(self, ok)
-  }
+	/// Draw the path object using current fill and stroke brushes.
+	pub fn draw_path(&mut self, path: &Path, mode: DRAW_PATH) -> Result<&mut Self> {
+		let ok = (_GAPI.gDrawPath)(self.0, path.0, mode);
+		ok_or!(self, ok)
+	}
 
-  /// Draw the whole image onto the graphics surface.
-  ///
-  /// With the current transformation applied (scale, rotation).
-  ///
-  /// Performance: expensive.
-  pub fn draw_image(&mut self, image: &Image, pos: Pos) -> Result<&mut Self> {
-    let ok = (_GAPI.gDrawImage)(self.0, image.0, pos.0, pos.1, None, None, None, None, None, None, None);
-    ok_or!(self, ok)
-  }
+	/// Draw the whole image onto the graphics surface.
+	///
+	/// With the current transformation applied (scale, rotation).
+	///
+	/// Performance: expensive.
+	pub fn draw_image(&mut self, image: &Image, pos: Pos) -> Result<&mut Self> {
+		let ok = (_GAPI.gDrawImage)(self.0, image.0, pos.0, pos.1, None, None, None, None, None, None, None);
+		ok_or!(self, ok)
+	}
 
-  /// Draw a part of the image onto the graphics surface.
-  ///
-  /// With the current transformation applied (scale, rotation).
-  ///
-  /// Performance: expensive.
-  pub fn draw_image_part(&mut self, image: &Image, dst_pos: Pos, dst_size: Size, src_pos: POINT, src_size: SIZE) -> Result<&mut Self> {
-    let ix = src_pos.x as UINT;
-    let iy = src_pos.y as UINT;
-    let iw = src_size.cx as UINT;
-    let ih = src_size.cy as UINT;
-    let ok = (_GAPI.gDrawImage)(
-      self.0,
-      image.0,
-      dst_pos.0,
-      dst_pos.1,
-      Some(&dst_size.0),
-      Some(&dst_size.1),
-      Some(&ix),
-      Some(&iy),
-      Some(&iw),
-      Some(&ih),
-      None,
-    );
-    ok_or!(self, ok)
-  }
+	/// Draw a part of the image onto the graphics surface.
+	///
+	/// With the current transformation applied (scale, rotation).
+	///
+	/// Performance: expensive.
+	pub fn draw_image_part(&mut self, image: &Image, dst_pos: Pos, dst_size: Size, src_pos: POINT, src_size: SIZE) -> Result<&mut Self> {
+		let ix = src_pos.x as UINT;
+		let iy = src_pos.y as UINT;
+		let iw = src_size.cx as UINT;
+		let ih = src_size.cy as UINT;
+		let ok = (_GAPI.gDrawImage)(
+			self.0,
+			image.0,
+			dst_pos.0,
+			dst_pos.1,
+			Some(&dst_size.0),
+			Some(&dst_size.1),
+			Some(&ix),
+			Some(&iy),
+			Some(&iw),
+			Some(&ih),
+			None,
+		);
+		ok_or!(self, ok)
+	}
 
-  /// Blend the image with the graphics surface.
-  ///
-  /// No affine transformations.
-  ///
-  /// Performance: less expensive.
-  pub fn blend_image(&mut self, image: &Image, dst_pos: Pos, opacity: f32) -> Result<&mut Self> {
-    let ok = (_GAPI.gDrawImage)(
-      self.0,
-      image.0,
-      dst_pos.0,
-      dst_pos.1,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      Some(&opacity),
-    );
-    ok_or!(self, ok)
-  }
+	/// Blend the image with the graphics surface.
+	///
+	/// No affine transformations.
+	///
+	/// Performance: less expensive.
+	pub fn blend_image(&mut self, image: &Image, dst_pos: Pos, opacity: f32) -> Result<&mut Self> {
+		let ok = (_GAPI.gDrawImage)(
+			self.0,
+			image.0,
+			dst_pos.0,
+			dst_pos.1,
+			None,
+			None,
+			None,
+			None,
+			None,
+			None,
+			Some(&opacity),
+		);
+		ok_or!(self, ok)
+	}
 
-  /// Blend a part of the image with the graphics surface.
-  ///
-  /// No affine transformations.
-  ///
-  /// Performance: less expensive.
-  pub fn blend_image_part(&mut self, image: &Image, dst_pos: Pos, opacity: f32, src_pos: POINT, src_size: SIZE) -> Result<&mut Self> {
-    let ix = src_pos.x as UINT;
-    let iy = src_pos.y as UINT;
-    let iw = src_size.cx as UINT;
-    let ih = src_size.cy as UINT;
-    let ok = (_GAPI.gDrawImage)(
-      self.0,
-      image.0,
-      dst_pos.0,
-      dst_pos.1,
-      None,
-      None,
-      Some(&ix),
-      Some(&iy),
-      Some(&iw),
-      Some(&ih),
-      Some(&opacity),
-    );
-    ok_or!(self, ok)
-  }
+	/// Blend a part of the image with the graphics surface.
+	///
+	/// No affine transformations.
+	///
+	/// Performance: less expensive.
+	pub fn blend_image_part(&mut self, image: &Image, dst_pos: Pos, opacity: f32, src_pos: POINT, src_size: SIZE) -> Result<&mut Self> {
+		let ix = src_pos.x as UINT;
+		let iy = src_pos.y as UINT;
+		let iw = src_size.cx as UINT;
+		let ih = src_size.cy as UINT;
+		let ok = (_GAPI.gDrawImage)(
+			self.0,
+			image.0,
+			dst_pos.0,
+			dst_pos.1,
+			None,
+			None,
+			Some(&ix),
+			Some(&iy),
+			Some(&iw),
+			Some(&ih),
+			Some(&opacity),
+		);
+		ok_or!(self, ok)
+	}
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,47 +1,33 @@
 //! Sciter host application helpers.
 
-use ::{_API};
-use capi::scdef::SCITER_RT_OPTIONS;
-use capi::sctypes::*;
-use capi::screquest::HREQUEST;
-use capi::schandler::NativeHandler;
-use dom::{self, event::EventHandler};
-use eventhandler::*;
-use value::{Value};
+use crate::_API;
+use crate::capi::scdef::SCITER_RT_OPTIONS;
+use crate::capi::schandler::NativeHandler;
+use crate::capi::screquest::HREQUEST;
+use crate::capi::sctypes::*;
+use crate::dom::{self, event::EventHandler};
+use crate::eventhandler::*;
+use crate::value::Value;
 
-pub use capi::scdef::{LOAD_RESULT, OUTPUT_SUBSYTEMS, OUTPUT_SEVERITY};
-pub use capi::scdef::{SCN_LOAD_DATA, SCN_DATA_LOADED, SCN_ATTACH_BEHAVIOR, SCN_INVALIDATE_RECT};
-
+pub use crate::capi::scdef::{LOAD_RESULT, OUTPUT_SEVERITY, OUTPUT_SUBSYTEMS};
+pub use crate::capi::scdef::{SCN_ATTACH_BEHAVIOR, SCN_DATA_LOADED, SCN_INVALIDATE_RECT, SCN_LOAD_DATA};
 
 /// A specialized `Result` type for Sciter host operations.
 pub type Result<T> = ::std::result::Result<T, ()>;
 
 macro_rules! ok_or {
 	($ok:ident) => {
-		if $ok != 0 {
-			Ok(())
-		} else {
-			Err(())
-		}
+		if $ok != 0 { Ok(()) } else { Err(()) }
 	};
 
 	($ok:ident, $rv:expr) => {
-		if $ok != 0 {
-			Ok($rv)
-		} else {
-			Err(())
-		}
+		if $ok != 0 { Ok($rv) } else { Err(()) }
 	};
 
 	($ok:ident, $rv:expr, $err:expr) => {
-		if $ok != 0 {
-			Ok($rv)
-		} else {
-			Err($err)
-		}
+		if $ok != 0 { Ok($rv) } else { Err($err) }
 	};
 }
-
 
 /** Sciter notification handler for [`Window.sciter_handler()`](../window/struct.Window.html#method.sciter_handler).
 
@@ -64,7 +50,6 @@ in order to send notifications while loading.
 */
 #[allow(unused_variables)]
 pub trait HostHandler {
-
 	/// Notifies that Sciter is about to download the referred resource.
 	///
 	/// You can load or overload data immediately by calling `self.data_ready()` with parameters provided by `SCN_LOAD_DATA`,
@@ -72,21 +57,25 @@ pub trait HostHandler {
 	///
 	/// Also you can discard the request (data will not be loaded at the document)
 	/// or take care about this request completely by yourself (via the [request API](../request/index.html)).
-	fn on_data_load(&mut self, pnm: &mut SCN_LOAD_DATA) -> Option<LOAD_RESULT> { return None; }
+	fn on_data_load(&mut self, pnm: &mut SCN_LOAD_DATA) -> Option<LOAD_RESULT> {
+		return None;
+	}
 
 	/// This notification indicates that external data (for example, image) download process completed.
-	fn on_data_loaded(&mut self, pnm: &SCN_DATA_LOADED) { }
+	fn on_data_loaded(&mut self, pnm: &SCN_DATA_LOADED) {}
 
 	/// This notification is sent on parsing the document and while processing elements
 	/// having non empty `behavior: ` style attribute value.
-	fn on_attach_behavior(&mut self, pnm: &mut SCN_ATTACH_BEHAVIOR) -> bool { return false; }
+	fn on_attach_behavior(&mut self, pnm: &mut SCN_ATTACH_BEHAVIOR) -> bool {
+		return false;
+	}
 
 	/// This notification is sent when instance of the engine is destroyed.
-	fn on_engine_destroyed(&mut self) { }
+	fn on_engine_destroyed(&mut self) {}
 
 	/// This notification is sent when the engine encounters critical rendering error: e.g. DirectX gfx driver error.
-  /// Most probably bad gfx drivers.
-	fn on_graphics_critical_failure(&mut self) { }
+	/// Most probably bad gfx drivers.
+	fn on_graphics_critical_failure(&mut self) {}
 
 	/// This notification is sent when the engine needs some area to be redrawn.
 	fn on_invalidate(&mut self, pnm: &SCN_INVALIDATE_RECT) {}
@@ -111,38 +100,31 @@ pub trait HostHandler {
 	fn data_ready(&self, hwnd: HWINDOW, uri: &str, data: &[u8], request_id: Option<HREQUEST>) {
 		let s = s2w!(uri);
 		match request_id {
-			Some(req) => {
-				(_API.SciterDataReadyAsync)(hwnd, s.as_ptr(), data.as_ptr(), data.len() as UINT, req)
-			},
-			None => {
-				(_API.SciterDataReady)(hwnd, s.as_ptr(), data.as_ptr(), data.len() as UINT)
-			},
+			Some(req) => (_API.SciterDataReadyAsync)(hwnd, s.as_ptr(), data.as_ptr(), data.len() as UINT, req),
+			None => (_API.SciterDataReady)(hwnd, s.as_ptr(), data.as_ptr(), data.len() as UINT),
 		};
 	}
 
-  /// This function is used as a response to the [`on_attach_behavior`](#method.on_attach_behavior) request
-  /// to attach a newly created behavior `handler` to the requested element.
+	/// This function is used as a response to the [`on_attach_behavior`](#method.on_attach_behavior) request
+	/// to attach a newly created behavior `handler` to the requested element.
 	fn attach_behavior<Handler: EventHandler>(&self, pnm: &mut SCN_ATTACH_BEHAVIOR, handler: Handler) {
 		// make native handler
 		let boxed = Box::new(handler);
-		let ptr = Box::into_raw(boxed);	// dropped in `_event_handler_proc`
-		pnm.elementProc = ::eventhandler::_event_handler_proc::<Handler>;
+		let ptr = Box::into_raw(boxed); // dropped in `_event_handler_proc`
+		pnm.elementProc = crate::eventhandler::_event_handler_proc::<Handler>;
 		pnm.elementTag = ptr as LPVOID;
 	}
 }
-
 
 /// Default `HostHandler` implementation
 #[derive(Default)]
 struct DefaultHandler;
 
 /// Default `HostHandler` implementation
-impl HostHandler for DefaultHandler {
+impl HostHandler for DefaultHandler {}
 
-}
-
-use std::rc::Rc;
 use std::cell::RefCell;
+use std::rc::Rc;
 
 type BehaviorList = Vec<(String, Box<dyn Fn() -> Box<dyn EventHandler>>)>;
 type SharedBehaviorList = Rc<RefCell<BehaviorList>>;
@@ -153,7 +135,7 @@ struct HostCallback<Callback> {
 	sig: u32,
 	behaviors: SharedBehaviorList,
 	handler: Callback,
-  archive: SharedArchive,
+	archive: SharedArchive,
 }
 
 /// Sciter host runtime support.
@@ -161,11 +143,10 @@ pub struct Host {
 	hwnd: HWINDOW,
 	behaviors: SharedBehaviorList,
 	handler: RefCell<NativeHandler>,
-  archive: SharedArchive,
+	archive: SharedArchive,
 }
 
 impl Host {
-
 	/// Attach Sciter host to an existing window.
 	///
 	/// Usually Sciter window is created by [`sciter::Window::create()`](../window/struct.Window.html#method.create),
@@ -177,25 +158,25 @@ impl Host {
 	pub fn attach(hwnd: HWINDOW) -> Host {
 		// Host with default debug handler installed
 		let host = Host {
-      hwnd,
-      behaviors: Default::default(),
-      handler: Default::default(),
-      archive: Default::default(),
-    };
+			hwnd,
+			behaviors: Default::default(),
+			handler: Default::default(),
+			archive: Default::default(),
+		};
 		host.setup_callback(DefaultHandler::default());
 		return host;
 	}
 
 	/// Attach Sciter host to an existing window with the given `Host` handler.
 	pub fn attach_with<Handler: HostHandler>(hwnd: HWINDOW, handler: Handler) -> Host {
-	  let host = Host {
-      hwnd,
-      behaviors: Default::default(),
-      handler: Default::default(),
-      archive: Default::default(),
-    };
-	  host.setup_callback(handler);
-	  return host;
+		let host = Host {
+			hwnd,
+			behaviors: Default::default(),
+			handler: Default::default(),
+			archive: Default::default(),
+		};
+		host.setup_callback(handler);
+		return host;
 	}
 
 	/// Attach [`dom::EventHandler`](../dom/event/trait.EventHandler.html) to the Sciter window.
@@ -207,22 +188,21 @@ impl Host {
 	#[doc(hidden)]
 	pub fn attach_handler<Handler: EventHandler>(&self, handler: Handler) {
 		let hwnd = self.get_hwnd();
-		let boxed = Box::new( WindowHandler { hwnd, handler } );
-		let ptr = Box::into_raw(boxed);	// dropped in `_event_handler_window_proc`
+		let boxed = Box::new(WindowHandler { hwnd, handler });
+		let ptr = Box::into_raw(boxed); // dropped in `_event_handler_window_proc`
 		// eprintln!("{}: {:?}", std::any::type_name::<Handler>(), ptr);
 
 		let func = _event_handler_window_proc::<Handler>;
 		let flags = dom::event::default_events();
-		(_API.SciterWindowAttachEventHandler)(hwnd, func, ptr as LPVOID, flags as UINT);
+		(_API.SciterWindowAttachEventHandler)(hwnd, func, ptr as LPVOID, flags.bits() as u32);
 	}
 
 	/// Set callback for Sciter engine events.
 	pub(crate) fn setup_callback<Callback: HostHandler>(&self, handler: Callback) {
-
 		let payload: HostCallback<Callback> = HostCallback {
 			sig: 17,
 			behaviors: Rc::clone(&self.behaviors),
-      archive: Rc::clone(&self.archive),
+			archive: Rc::clone(&self.archive),
 			handler: handler,
 		};
 
@@ -238,20 +218,20 @@ impl Host {
 	/// See the [`Window::register_behavior`](../window/struct.Window.html#method.register_behavior) for an example.
 	pub fn register_behavior<Factory>(&self, name: &str, factory: Factory)
 	where
-		Factory: Fn() -> Box<dyn EventHandler> + 'static
+		Factory: Fn() -> Box<dyn EventHandler> + 'static,
 	{
 		let make: Box<dyn Fn() -> Box<dyn EventHandler>> = Box::new(factory);
 		let pair = (name.to_owned(), make);
 		self.behaviors.borrow_mut().push(pair);
 	}
 
-  /// Register an archive produced by `packfolder`.
-  ///
-  /// See documentation of the [`Archive`](struct.Archive.html).
-  pub fn register_archive(&self, resource: &[u8]) -> Result<()> {
-    *self.archive.borrow_mut() = Some(Archive::open(resource)?);
-    Ok(())
-  }
+	/// Register an archive produced by `packfolder`.
+	///
+	/// See documentation of the [`Archive`](struct.Archive.html).
+	pub fn register_archive(&self, resource: &[u8]) -> Result<()> {
+		*self.archive.borrow_mut() = Some(Archive::open(resource)?);
+		Ok(())
+	}
 
 	/// Set debug mode for this window.
 	pub fn enable_debug(&self, enable: bool) {
@@ -281,10 +261,8 @@ impl Host {
 			Some(uri) => {
 				let s = s2w!(uri);
 				(_API.SciterLoadHtml)(self.hwnd, html.as_ptr(), html.len() as UINT, s.as_ptr()) != 0
-			},
-			None => {
-				(_API.SciterLoadHtml)(self.hwnd, html.as_ptr(), html.len() as UINT, 0 as LPCWSTR) != 0
 			}
+			None => (_API.SciterLoadHtml)(self.hwnd, html.as_ptr(), html.len() as UINT, 0 as LPCWSTR) != 0,
 		}
 	}
 
@@ -311,7 +289,7 @@ impl Host {
 	///
 	/// This function returns `Result<Value,Value>` with script function result value or with Sciter script error.
 	pub fn eval_script(&self, script: &str) -> ::std::result::Result<Value, Value> {
-		let (s,n) = s2wn!(script);
+		let (s, n) = s2wn!(script);
 		let mut rv = Value::new();
 		let ok = (_API.SciterEval)(self.hwnd, s.as_ptr(), n, rv.as_ptr());
 		ok_or!(ok, rv, rv)
@@ -406,15 +384,15 @@ impl Host {
 		let ok = (_API.SciterSetCSS)(self.hwnd, b.as_ptr(), n, url.as_ptr(), media.as_ptr());
 		ok_or!(ok)
 	}
-
 }
-
 
 // Sciter notification handler.
 // This comes as free function due to https://github.com/rust-lang/rust/issues/32364
-extern "system" fn _on_handle_notification<T: HostHandler>(pnm: *mut ::capi::scdef::SCITER_CALLBACK_NOTIFICATION, param: LPVOID) -> UINT
-{
-	use capi::scdef::{SCITER_NOTIFICATION, SCITER_CALLBACK_NOTIFICATION};
+extern "system" fn _on_handle_notification<T: HostHandler>(
+	pnm: *mut crate::capi::scdef::SCITER_CALLBACK_NOTIFICATION,
+	param: LPVOID,
+) -> UINT {
+	use crate::capi::scdef::{SCITER_CALLBACK_NOTIFICATION, SCITER_NOTIFICATION};
 
 	// reconstruct pointer to Handler
 	let callback = NativeHandler::get_data::<HostCallback<T>>(&param);
@@ -424,33 +402,32 @@ extern "system" fn _on_handle_notification<T: HostHandler>(pnm: *mut ::capi::scd
 	let nm: &mut SCITER_CALLBACK_NOTIFICATION = unsafe { &mut *pnm };
 	let code: SCITER_NOTIFICATION = unsafe { ::std::mem::transmute(nm.code) };
 
-
 	let result: UINT = match code {
 		SCITER_NOTIFICATION::SC_LOAD_DATA => {
 			let scnm = pnm as *mut SCN_LOAD_DATA;
-      let scnm = unsafe { &mut *scnm };
+			let scnm = unsafe { &mut *scnm };
 			let mut re = me.on_data_load(scnm);
-      if re.is_none() {
-        if let Some(archive) = callback.archive.borrow().as_ref() {
-          let uri = w2s!(scnm.uri);
-          if uri.starts_with("this://app/") {
-            if let Some(data) = archive.get(&uri) {
-              me.data_ready(scnm.hwnd, &uri, data, None);
-            } else {
-              eprintln!("[sciter] error: can't load {:?}", uri);
-            }
-          }
-          re = Some(LOAD_RESULT::LOAD_DEFAULT);
-        }
-      }
+			if re.is_none() {
+				if let Some(archive) = callback.archive.borrow().as_ref() {
+					let uri = w2s!(scnm.uri);
+					if uri.starts_with("this://app/") {
+						if let Some(data) = archive.get(&uri) {
+							me.data_ready(scnm.hwnd, &uri, data, None);
+						} else {
+							eprintln!("[sciter] error: can't load {:?}", uri);
+						}
+					}
+					re = Some(LOAD_RESULT::LOAD_DEFAULT);
+				}
+			}
 			re.unwrap_or(LOAD_RESULT::LOAD_DEFAULT) as UINT
-		},
+		}
 
 		SCITER_NOTIFICATION::SC_DATA_LOADED => {
 			let scnm = pnm as *mut SCN_DATA_LOADED;
-			me.on_data_loaded(unsafe { &mut *scnm } );
+			me.on_data_loaded(unsafe { &mut *scnm });
 			0
-		},
+		}
 
 		SCITER_NOTIFICATION::SC_ATTACH_BEHAVIOR => {
 			let scnm = pnm as *mut SCN_ATTACH_BEHAVIOR;
@@ -458,33 +435,29 @@ extern "system" fn _on_handle_notification<T: HostHandler>(pnm: *mut ::capi::scd
 			let mut re = me.on_attach_behavior(scnm);
 			if !re {
 				let name = u2s!(scnm.name);
-				let behavior = callback.behaviors
-					.borrow()
-					.iter()
-					.find(|x| x.0 == name)
-					.map(|x| x.1());
+				let behavior = callback.behaviors.borrow().iter().find(|x| x.0 == name).map(|x| x.1());
 
 				if let Some(behavior) = behavior {
-					let boxed = Box::new( BoxedHandler { handler: behavior } );
-					let ptr = Box::into_raw(boxed);	// dropped in `_event_handler_behavior_proc`
+					let boxed = Box::new(BoxedHandler { handler: behavior });
+					let ptr = Box::into_raw(boxed); // dropped in `_event_handler_behavior_proc`
 
-					scnm.elementProc = ::eventhandler::_event_handler_behavior_proc;
+					scnm.elementProc = crate::eventhandler::_event_handler_behavior_proc;
 					scnm.elementTag = ptr as LPVOID;
 					re = true;
 				}
 			}
 			re as UINT
-		},
+		}
 
 		SCITER_NOTIFICATION::SC_ENGINE_DESTROYED => {
 			me.on_engine_destroyed();
 			0
-		},
+		}
 
 		SCITER_NOTIFICATION::SC_GRAPHICS_CRITICAL_FAILURE => {
 			me.on_graphics_critical_failure();
 			0
-		},
+		}
 
 		SCITER_NOTIFICATION::SC_INVALIDATE_RECT => {
 			let scnm = pnm as *const SCN_INVALIDATE_RECT;
@@ -499,16 +472,19 @@ extern "system" fn _on_handle_notification<T: HostHandler>(pnm: *mut ::capi::scd
 }
 
 // Sciter debug output handler.
-extern "system" fn _on_debug_notification<T: HostHandler>(param: LPVOID, subsystem: OUTPUT_SUBSYTEMS, severity: OUTPUT_SEVERITY,
-	text: LPCWSTR, _text_length: UINT)
-{
+extern "system" fn _on_debug_notification<T: HostHandler>(
+	param: LPVOID,
+	subsystem: OUTPUT_SUBSYTEMS,
+	severity: OUTPUT_SEVERITY,
+	text: LPCWSTR,
+	_text_length: UINT,
+) {
 	// reconstruct pointer to Handler
 	// let me = unsafe { &mut *(param as *mut HostCallback<T>) };
 	let me = NativeHandler::get_data::<HostCallback<T>>(&param);
-	let message = ::utf::w2s(text).replace("\r", "\n");
+	let message = crate::utf::w2s(text).replace("\r", "\n");
 	me.handler.on_debug_output(subsystem, severity, message.trim_end());
 }
-
 
 /// Sciter compressed archive.
 ///
@@ -541,46 +517,42 @@ pub struct Archive(HSARCHIVE);
 
 /// Close the archive.
 impl Drop for Archive {
-  fn drop(&mut self) {
-    (_API.SciterCloseArchive)(self.0);
-  }
+	fn drop(&mut self) {
+		(_API.SciterCloseArchive)(self.0);
+	}
 }
 
 impl Archive {
-  /// Open an archive blob.
-  pub fn open(archived: &[u8]) -> Result<Self> {
-    let p = (_API.SciterOpenArchive)(archived.as_ptr(), archived.len() as u32);
-    if !p.is_null() {
-      Ok(Archive(p))
-    } else {
-      Err(())
-    }
-  }
+	/// Open an archive blob.
+	pub fn open(archived: &[u8]) -> Result<Self> {
+		let p = (_API.SciterOpenArchive)(archived.as_ptr(), archived.len() as u32);
+		if !p.is_null() { Ok(Archive(p)) } else { Err(()) }
+	}
 
-  /// Get an archive item.
-  ///
-  /// Given a path, returns a reference to the contents of an archived item.
-  pub fn get(&self, path: &str) -> Option<&[u8]> {
-    // skip initial part of the path
-    let skip = if path.starts_with("this://app/") {
-      "this://app/".len()
-    } else if path.starts_with("//") {
-      "//".len()
-    } else {
-      0
-    };
+	/// Get an archive item.
+	///
+	/// Given a path, returns a reference to the contents of an archived item.
+	pub fn get(&self, path: &str) -> Option<&[u8]> {
+		// skip initial part of the path
+		let skip = if path.starts_with("this://app/") {
+			"this://app/".len()
+		} else if path.starts_with("//") {
+			"//".len()
+		} else {
+			0
+		};
 
-    let wname = s2w!(path);
-    let name = &wname[skip..];
+		let wname = s2w!(path);
+		let name = &wname[skip..];
 
-    let mut pb = ::std::ptr::null();
-    let mut cb = 0;
-    let ok = (_API.SciterGetArchiveItem)(self.0, name.as_ptr(), &mut pb, &mut cb);
-    if ok != 0 && !pb.is_null() {
-      let data = unsafe { ::std::slice::from_raw_parts(pb, cb as usize) };
-      Some(data)
-    } else {
-      None
-    }
-  }
+		let mut pb = ::std::ptr::null();
+		let mut cb = 0;
+		let ok = (_API.SciterGetArchiveItem)(self.0, name.as_ptr(), &mut pb, &mut cb);
+		if ok != 0 && !pb.is_null() {
+			let data = unsafe { ::std::slice::from_raw_parts(pb, cb as usize) };
+			Some(data)
+		} else {
+			None
+		}
+	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,9 @@ Here is a minimal sciter app:
 extern crate sciter;
 
 fn main() {
-    let mut frame = sciter::Window::new();
-    frame.load_file("minimal.htm");
-    frame.run_app();
+		let mut frame = sciter::Window::new();
+		frame.load_file("minimal.htm");
+		frame.run_app();
 }
 ```
 
@@ -54,42 +54,44 @@ folder for more complex usage and module-level sections for the guides about:
 
 */
 
-#![doc(html_logo_url = "https://sciter.com/screenshots/slide-sciter-osx.png",
-       html_favicon_url = "https://sciter.com/wp-content/themes/sciter/!images/favicon.ico")]
-
+#![doc(
+	html_logo_url = "https://sciter.com/screenshots/slide-sciter-osx.png",
+	html_favicon_url = "https://sciter.com/wp-content/themes/sciter/!images/favicon.ico"
+)]
 // documentation test:
 // #![warn(missing_docs)]
 
-
 /* Clippy lints */
-
 #![allow(clippy::needless_return, clippy::let_and_return)] // past habits
 #![allow(clippy::redundant_field_names)] // since Rust 1.17 and less readable
 #![allow(clippy::unreadable_literal)] // C++ SDK constants
-#![allow(clippy::upper_case_acronyms)]// C++ SDK constants
-#![allow(clippy::deprecated_semver)]  // `#[deprecated(since="Sciter 4.4.3.24")]` is not a semver format.
-#![allow(clippy::result_unit_err)]		// Sciter returns BOOL, but `Result<(), ()>` is more strict even without error description.
+#![allow(clippy::upper_case_acronyms)] // C++ SDK constants
+#![allow(clippy::deprecated_semver)] // `#[deprecated(since="Sciter 4.4.3.24")]` is not a semver format.
+#![allow(clippy::result_unit_err)] // Sciter returns BOOL, but `Result<(), ()>` is more strict even without error description.
 // #![allow(clippy::cast_ptr_alignment)] // 0.0.195 only
-
 
 /* Macros */
 
 #[cfg(target_os = "macos")]
-#[macro_use] extern crate objc;
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate objc;
+#[macro_use]
+extern crate lazy_static;
 
-
-#[macro_use] pub mod macros;
+#[macro_use]
+pub mod macros;
 
 mod capi;
 
+pub use crate::capi::scbehavior::{DRAW_EVENTS, EVENT_GROUPS, PHASE_MASK, BEHAVIOR_EVENTS};
+
+pub use crate::capi::scdef::{GFX_LAYER, SCRIPT_RUNTIME_FEATURES};
 #[doc(hidden)]
-pub use capi::scdom::{HELEMENT};
-pub use capi::scdef::{GFX_LAYER, SCRIPT_RUNTIME_FEATURES};
+pub use capi::scdom::HELEMENT;
 
 /* Rust interface */
-mod platform;
 mod eventhandler;
+mod platform;
 
 pub mod dom;
 pub mod graphics;
@@ -106,9 +108,8 @@ pub mod windowless;
 pub use dom::Element;
 pub use dom::event::EventHandler;
 pub use host::{Archive, Host, HostHandler};
-pub use value::{Value, FromValue};
+pub use value::{FromValue, Value};
 pub use window::Window;
-
 
 /// Builder pattern for window creation. See [`window::Builder`](window/struct.Builder.html) documentation.
 ///
@@ -123,9 +124,8 @@ pub use window::Window;
 /// ```
 pub type WindowBuilder = window::Builder;
 
-
 /* Loader */
-pub use capi::scapi::{ISciterAPI};
+pub use capi::scapi::ISciterAPI;
 use capi::scgraphics::SciterGraphicsAPI;
 use capi::screquest::SciterRequestAPI;
 
@@ -137,230 +137,235 @@ mod ext {
 	// However it is quite inconvenient now (e.g. we can not put x64 and x86 builds in %PATH%)
 	//
 	#![allow(non_snake_case, non_camel_case_types)]
-	use capi::scapi::{ISciterAPI};
-	use capi::sctypes::{LPCSTR, LPCVOID, BOOL};
+	use crate::capi::scapi::ISciterAPI;
+	use crate::capi::sctypes::{BOOL, LPCSTR, LPCVOID};
+	use std::sync::OnceLock;
 
-  type ApiType = *const ISciterAPI;
-	type FuncType = extern "system" fn () -> *const ISciterAPI;
+	type ApiType = *const ISciterAPI;
+	type FuncType = extern "system" fn() -> *const ISciterAPI;
 
-  pub static mut CUSTOM_DLL_PATH: Option<String> = None;
+	pub static CUSTOM_DLL_PATH: OnceLock<String> = OnceLock::new();
 
-	extern "system"
-	{
+	unsafe extern "system" {
 		fn LoadLibraryA(lpFileName: LPCSTR) -> LPCVOID;
-    fn FreeLibrary(dll: LPCVOID) -> BOOL;
+		fn FreeLibrary(dll: LPCVOID) -> BOOL;
 		fn GetProcAddress(hModule: LPCVOID, lpProcName: LPCSTR) -> LPCVOID;
 	}
 
-  pub fn try_load_library(permanent: bool) -> ::std::result::Result<ApiType, String> {
-    use std::ffi::CString;
-    use std::path::Path;
+	pub fn try_load_library(permanent: bool) -> ::std::result::Result<ApiType, String> {
+		use std::ffi::CString;
+		use std::path::Path;
 
-    fn try_load(path: &Path) -> Option<LPCVOID> {
-      let path = CString::new(format!("{}", path.display())).expect("invalid library path");
-      let dll = unsafe { LoadLibraryA(path.as_ptr()) };
-      if !dll.is_null() {
-        Some(dll)
-      } else {
-        None
-      }
-    }
+		fn try_load(path: &Path) -> Option<LPCVOID> {
+			let path = CString::new(format!("{}", path.display())).expect("invalid library path");
+			let dll = unsafe { LoadLibraryA(path.as_ptr()) };
+			if !dll.is_null() { Some(dll) } else { None }
+		}
 
-    fn in_global() -> Option<LPCVOID> {
-      // modern dll name
-      let mut dll = unsafe { LoadLibraryA(b"sciter.dll\0".as_ptr() as LPCSTR) };
-      if dll.is_null() {
-        // try to load with old names
-        let alternate = if cfg!(target_arch = "x86_64") { b"sciter64.dll\0" } else { b"sciter32.dll\0" };
-        dll = unsafe { LoadLibraryA(alternate.as_ptr() as LPCSTR) };
-      }
-      if !dll.is_null() {
-        Some(dll)
-      } else {
-        None
-      }
-    }
+		fn in_global() -> Option<LPCVOID> {
+			// modern dll name
+			let mut dll = unsafe { LoadLibraryA(b"sciter.dll\0".as_ptr() as LPCSTR) };
+			if dll.is_null() {
+				// try to load with old names
+				let alternate = if cfg!(target_arch = "x86_64") {
+					b"sciter64.dll\0"
+				} else {
+					b"sciter32.dll\0"
+				};
+				dll = unsafe { LoadLibraryA(alternate.as_ptr() as LPCSTR) };
+			}
+			if !dll.is_null() { Some(dll) } else { None }
+		}
 
-    // try specified path first (and only if present)
-    // and several paths to lookup then
-    let dll = if let Some(path) = unsafe { CUSTOM_DLL_PATH.as_ref() } {
-      try_load(Path::new(path))
-    } else {
-      in_global()
-    };
+		// try specified path first (and only if present)
+		// and several paths to lookup then
+		let dll = if let Some(path) = CUSTOM_DLL_PATH.get() {
+			try_load(Path::new(path))
+		} else {
+			in_global()
+		};
 
-    if let Some(dll) = dll {
-      // get the "SciterAPI" exported symbol
-      let sym = unsafe { GetProcAddress(dll, b"SciterAPI\0".as_ptr() as LPCSTR) };
-      if sym.is_null() {
-        return Err("\"SciterAPI\" function was expected in the loaded library.".to_owned());
-      }
+		if let Some(dll) = dll {
+			// get the "SciterAPI" exported symbol
+			let sym = unsafe { GetProcAddress(dll, b"SciterAPI\0".as_ptr() as LPCSTR) };
+			if sym.is_null() {
+				return Err("\"SciterAPI\" function was expected in the loaded library.".to_owned());
+			}
 
-      if !permanent {
-        unsafe { FreeLibrary(dll) };
-        return Ok(0 as ApiType);
-      }
+			if !permanent {
+				unsafe { FreeLibrary(dll) };
+				return Ok(0 as ApiType);
+			}
 
-      let get_api: FuncType = unsafe { std::mem::transmute(sym) };
-      return Ok(get_api());
-    }
-    let sdkbin = if cfg!(target_arch = "x86_64") { "bin/64" } else { "bin/32" };
-    let msg = format!("Please verify that Sciter SDK is installed and its binaries (from SDK/{}) are available in PATH.", sdkbin);
-    Err(format!("error: '{}' was not found neither in PATH nor near the current executable.\n  {}", "sciter.dll", msg))
-  }
+			let get_api: FuncType = unsafe { std::mem::transmute(sym) };
+			return Ok(get_api());
+		}
+		let sdkbin = if cfg!(target_arch = "x86_64") { "bin/64" } else { "bin/32" };
+		let msg = format!(
+			"Please verify that Sciter SDK is installed and its binaries (from SDK/{}) are available in PATH.",
+			sdkbin
+		);
+		Err(format!(
+			"error: '{}' was not found neither in PATH nor near the current executable.\n  {}",
+			"sciter.dll", msg
+		))
+	}
 
 	pub unsafe fn SciterAPI() -> *const ISciterAPI {
-    match try_load_library(true) {
-      Ok(api) => api,
-      Err(error) => panic!("{}", error),
-    }
+		match try_load_library(true) {
+			Ok(api) => api,
+			Err(error) => panic!("{}", error),
+		}
 	}
 }
 
 #[cfg(all(feature = "dynamic", unix))]
 mod ext {
-  #![allow(non_snake_case, non_camel_case_types)]
-  extern crate libc;
+	#![allow(non_snake_case, non_camel_case_types)]
+	extern crate libc;
 
-  pub static mut CUSTOM_DLL_PATH: Option<String> = None;
+	pub static mut CUSTOM_DLL_PATH: Option<String> = None;
 
-  #[cfg(target_os = "linux")]
-  const DLL_NAMES: &[&str] = &[ "libsciter-gtk.so" ];
+	#[cfg(target_os = "linux")]
+	const DLL_NAMES: &[&str] = &["libsciter-gtk.so"];
 
 	// "libsciter.dylib" since Sciter 4.4.6.3.
-  #[cfg(target_os = "macos")]
-  const DLL_NAMES: &[&str] = &[ "libsciter.dylib", "sciter-osx-64.dylib" ];
+	#[cfg(target_os = "macos")]
+	const DLL_NAMES: &[&str] = &["libsciter.dylib", "sciter-osx-64.dylib"];
 
-  use capi::scapi::ISciterAPI;
-  use capi::sctypes::{LPVOID, LPCSTR};
+	use capi::scapi::ISciterAPI;
+	use capi::sctypes::{LPCSTR, LPVOID};
 
-  type FuncType = extern "system" fn () -> *const ISciterAPI;
-  type ApiType = *const ISciterAPI;
+	type FuncType = extern "system" fn() -> *const ISciterAPI;
+	type ApiType = *const ISciterAPI;
 
+	pub fn try_load_library(permanent: bool) -> ::std::result::Result<ApiType, String> {
+		use std::ffi::CString;
+		use std::os::unix::ffi::OsStrExt;
+		use std::path::Path;
 
-  pub fn try_load_library(permanent: bool) -> ::std::result::Result<ApiType, String> {
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt;
-    use std::path::{Path};
+		// Try to load the library from a specified absolute path.
+		fn try_load(path: &Path) -> Option<LPVOID> {
+			let bytes = path.as_os_str().as_bytes();
+			if let Ok(cstr) = CString::new(bytes) {
+				let dll = unsafe { libc::dlopen(cstr.as_ptr(), libc::RTLD_LOCAL | libc::RTLD_LAZY) };
+				if !dll.is_null() {
+					return Some(dll);
+				}
+			}
+			None
+		}
 
+		// Try to find a library (by one of its names) in a specified path.
+		fn try_load_from(dir: Option<&Path>) -> Option<LPVOID> {
+			let dll = DLL_NAMES
+				.iter()
+				.map(|name| {
+					let mut path = dir.map(Path::to_owned).unwrap_or_default();
+					path.push(name);
+					path
+				})
+				.map(|path| try_load(&path))
+				.find(|dll| dll.is_some())
+				.map(|o| o.unwrap());
 
-    // Try to load the library from a specified absolute path.
-    fn try_load(path: &Path) -> Option<LPVOID> {
-      let bytes = path.as_os_str().as_bytes();
-      if let Ok(cstr) = CString::new(bytes) {
-        let dll = unsafe { libc::dlopen(cstr.as_ptr(), libc::RTLD_LOCAL | libc::RTLD_LAZY) };
-        if !dll.is_null() {
-          return Some(dll)
-        }
-      }
-      None
-    }
+			if dll.is_some() {
+				return dll;
+			}
 
-    // Try to find a library (by one of its names) in a specified path.
-    fn try_load_from(dir: Option<&Path>) -> Option<LPVOID> {
+			None
+		}
 
-      let dll = DLL_NAMES.iter()
-        .map(|name| {
-          let mut path = dir.map(Path::to_owned).unwrap_or_default();
-          path.push(name);
-          path
-        })
-        .map(|path| try_load(&path))
-        .find(|dll| dll.is_some())
-        .map(|o| o.unwrap());
+		// Try to load from the current directory.
+		fn in_current_dir() -> Option<LPVOID> {
+			if let Ok(dir) = ::std::env::current_exe() {
+				if let Some(dir) = dir.parent() {
+					let dll = try_load_from(Some(dir));
+					if dll.is_some() {
+						return dll;
+					}
 
-      if dll.is_some() {
-        return dll;
-      }
-
-      None
-    }
-
-    // Try to load from the current directory.
-    fn in_current_dir() -> Option<LPVOID> {
-      if let Ok(dir) = ::std::env::current_exe() {
-        if let Some(dir) = dir.parent() {
-          let dll = try_load_from(Some(dir));
-          if dll.is_some() {
-            return dll;
-          }
-
-          if cfg!(target_os = "macos") {
-            // "(bundle folder)/Contents/Frameworks/"
-            let mut path = dir.to_owned();
-            path.push("../Frameworks/libsciter.dylib");
-            let dll = try_load(&path);
+					if cfg!(target_os = "macos") {
+						// "(bundle folder)/Contents/Frameworks/"
+						let mut path = dir.to_owned();
+						path.push("../Frameworks/libsciter.dylib");
+						let dll = try_load(&path);
 						if dll.is_some() {
 							return dll;
 						}
 
-            let mut path = dir.to_owned();
-            path.push("../Frameworks/sciter-osx-64.dylib");
-            let dll = try_load(&path);
+						let mut path = dir.to_owned();
+						path.push("../Frameworks/sciter-osx-64.dylib");
+						let dll = try_load(&path);
 						if dll.is_some() {
 							return dll;
 						}
-          }
-        }
-      }
-      None
-    }
+					}
+				}
+			}
+			None
+		}
 
-    // Try to load indirectly via `dlopen("dll.so")`.
-    fn in_global() -> Option<LPVOID> {
-      try_load_from(None)
-    }
+		// Try to load indirectly via `dlopen("dll.so")`.
+		fn in_global() -> Option<LPVOID> {
+			try_load_from(None)
+		}
 
-    // Try to find in $PATH.
-    fn in_paths() -> Option<LPVOID> {
-      use std::env;
-      if let Some(paths) = env::var_os("PATH") {
-        for path in env::split_paths(&paths) {
-          if let Some(dll) = try_load_from(Some(&path)) {
-            return Some(dll);
-          }
-        }
-      }
-      None
-    }
+		// Try to find in $PATH.
+		fn in_paths() -> Option<LPVOID> {
+			use std::env;
+			if let Some(paths) = env::var_os("PATH") {
+				for path in env::split_paths(&paths) {
+					if let Some(dll) = try_load_from(Some(&path)) {
+						return Some(dll);
+					}
+				}
+			}
+			None
+		}
 
-    // try specified path first (and only if present)
-    // and several paths to lookup then
-    let dll = if let Some(path) = unsafe { CUSTOM_DLL_PATH.as_ref() } {
-      try_load(Path::new(path))
-    } else {
-      in_current_dir().or_else(in_paths).or_else(in_global)
-    };
+		// try specified path first (and only if present)
+		// and several paths to lookup then
+		let dll = if let Some(path) = unsafe { CUSTOM_DLL_PATH.as_ref() } {
+			try_load(Path::new(path))
+		} else {
+			in_current_dir().or_else(in_paths).or_else(in_global)
+		};
 
-    if let Some(dll) = dll {
-      // get the "SciterAPI" exported symbol
-      let sym = unsafe { libc::dlsym(dll, b"SciterAPI\0".as_ptr() as LPCSTR) };
-      if sym.is_null() {
-        return Err("\"SciterAPI\" function was expected in the loaded library.".to_owned());
-      }
+		if let Some(dll) = dll {
+			// get the "SciterAPI" exported symbol
+			let sym = unsafe { libc::dlsym(dll, b"SciterAPI\0".as_ptr() as LPCSTR) };
+			if sym.is_null() {
+				return Err("\"SciterAPI\" function was expected in the loaded library.".to_owned());
+			}
 
-      if !permanent {
-        unsafe { libc::dlclose(dll) };
-        return Ok(0 as ApiType);
-      }
+			if !permanent {
+				unsafe { libc::dlclose(dll) };
+				return Ok(0 as ApiType);
+			}
 
-      let get_api: FuncType = unsafe { std::mem::transmute(sym) };
-      return Ok(get_api());
-    }
+			let get_api: FuncType = unsafe { std::mem::transmute(sym) };
+			return Ok(get_api());
+		}
 
-    let sdkbin = if cfg!(target_os = "macos") { "bin.osx" } else { "bin.lnx" };
-    let msg = format!("Please verify that Sciter SDK is installed and its binaries (from {}) are available in PATH.", sdkbin);
-    Err(format!("error: '{}' was not found neither in PATH nor near the current executable.\n  {}", DLL_NAMES[0], msg))
-  }
+		let sdkbin = if cfg!(target_os = "macos") { "bin.osx" } else { "bin.lnx" };
+		let msg = format!(
+			"Please verify that Sciter SDK is installed and its binaries (from {}) are available in PATH.",
+			sdkbin
+		);
+		Err(format!(
+			"error: '{}' was not found neither in PATH nor near the current executable.\n  {}",
+			DLL_NAMES[0], msg
+		))
+	}
 
-  pub fn SciterAPI() -> *const ISciterAPI {
-    match try_load_library(true) {
-      Ok(api) => api,
-      Err(error) => panic!("{}", error),
-    }
-  }
+	pub fn SciterAPI() -> *const ISciterAPI {
+		match try_load_library(true) {
+			Ok(api) => api,
+			Err(error) => panic!("{}", error),
+		}
+	}
 }
-
 
 #[cfg(all(target_os = "linux", not(feature = "dynamic")))]
 mod ext {
@@ -369,13 +374,17 @@ mod ext {
 	// Since 3.3.1.6 library name was changed to "libsciter".
 	// However CC requires `-l sciter` form.
 	#[link(name = "sciter-gtk")]
-	extern "system" { pub fn SciterAPI() -> *const ::capi::scapi::ISciterAPI;	}
+	extern "system" {
+		pub fn SciterAPI() -> *const ::capi::scapi::ISciterAPI;
+	}
 }
 
 #[cfg(all(target_os = "macos", target_arch = "x86_64", not(feature = "dynamic")))]
 mod ext {
 	#[link(name = "libsciter", kind = "dylib")]
-	extern "system" { pub fn SciterAPI() -> *const ::capi::scapi::ISciterAPI;	}
+	extern "system" {
+		pub fn SciterAPI() -> *const ::capi::scapi::ISciterAPI;
+	}
 }
 
 /// Getting ISciterAPI reference, can be used for manual API calling.
@@ -383,15 +392,15 @@ mod ext {
 #[allow(non_snake_case)]
 pub fn SciterAPI<'a>() -> &'a ISciterAPI {
 	let ap = unsafe {
-		if cfg!(feature="extension") {
+		if cfg!(feature = "extension") {
 			// TODO: it's not good to raise a panic inside `lazy_static!`,
-      // because it wents into recursive panicing.
-      //
+			// because it wents into recursive panicing.
+			//
 			// Somehow, `cargo test --all` tests all the features,
-      // also sometimes it comes even without `cfg!(test)`.
-      // Well, the culprit is "examples/extensions" which uses the "extension" feature,
-      // but how on earth it builds without `cfg(test)`?
-      //
+			// also sometimes it comes even without `cfg!(test)`.
+			// Well, the culprit is "examples/extensions" which uses the "extension" feature,
+			// but how on earth it builds without `cfg(test)`?
+			//
 			if cfg!(test) {
 				&*ext::SciterAPI()
 			} else {
@@ -423,7 +432,7 @@ pub fn SciterAPI<'a>() -> &'a ISciterAPI {
 #[allow(non_snake_case)]
 pub fn SciterAPI_unchecked<'a>() -> &'a ISciterAPI {
 	let ap = unsafe {
-		if cfg!(feature="extension") {
+		if cfg!(feature = "extension") {
 			EXT_API.expect("Sciter API is not available yet, call `sciter::set_api()` first.")
 		} else {
 			&*ext::SciterAPI()
@@ -432,7 +441,6 @@ pub fn SciterAPI_unchecked<'a>() -> &'a ISciterAPI {
 
 	return ap;
 }
-
 
 lazy_static! {
 	static ref _API: &'static ISciterAPI = SciterAPI();
@@ -459,20 +467,18 @@ lazy_static! {
 /// }
 /// ```
 pub fn set_library(custom_path: &str) -> ::std::result::Result<(), String> {
-  #[cfg(not(feature = "dynamic"))]
-  fn set_impl(_: &str) -> ::std::result::Result<(), String> {
-    Err("Don't use `sciter::set_library()` in static builds.\n  Build with the feature \"dynamic\" instead.".to_owned())
-  }
+	#[cfg(not(feature = "dynamic"))]
+	fn set_impl(_: &str) -> ::std::result::Result<(), String> {
+		Err("Don't use `sciter::set_library()` in static builds.\n  Build with the feature \"dynamic\" instead.".to_owned())
+	}
 
-  #[cfg(feature = "dynamic")]
-  fn set_impl(path: &str) -> ::std::result::Result<(), String> {
-    unsafe {
-      ext::CUSTOM_DLL_PATH = Some(path.to_owned());
-    }
-    ext::try_load_library(false).map(|_| ())
-  }
+	#[cfg(feature = "dynamic")]
+	fn set_impl(path: &str) -> ::std::result::Result<(), String> {
+		ext::CUSTOM_DLL_PATH.set(path.to_owned())?;
+		ext::try_load_library(false).map(|_| ())
+	}
 
-  set_impl(custom_path)
+	set_impl(custom_path)
 }
 
 static mut EXT_API: Option<&'static ISciterAPI> = None;
@@ -480,11 +486,12 @@ static mut EXT_API: Option<&'static ISciterAPI> = None;
 /// Set the Sciter API coming from `SciterLibraryInit`.
 ///
 /// Note: Must be called first before any other function.
-pub fn set_host_api(api: &'static ISciterAPI) {
-	if cfg!(feature="extension") {
-		unsafe {
-			EXT_API.replace(api);
-		}
+pub fn set_host_api(_api: &'static ISciterAPI) {
+	if cfg!(feature = "extension") {
+		unimplemented!("EXT_API is not used anywhere yet");
+		// unsafe {
+		// 		EXT_API.replace(api);
+		// }
 	}
 }
 
@@ -493,7 +500,7 @@ pub fn set_host_api(api: &'static ISciterAPI) {
 /// Note: does not return the `build` part because it doesn't fit in `0..255` byte range.
 /// Use [`sciter::version()`](fn.version.html) instead which returns the complete version string.
 pub fn version_num() -> u32 {
-	use types::BOOL;
+	use crate::types::BOOL;
 	let v1 = (_API.SciterVersion)(true as BOOL);
 	let v2 = (_API.SciterVersion)(false as BOOL);
 	let (major, minor, revision, _build) = (v1 >> 16 & 0xFF, v1 & 0xFF, v2 >> 16 & 0xFF, v2 & 0xFF);
@@ -504,7 +511,7 @@ pub fn version_num() -> u32 {
 
 /// Sciter engine version string (e.g. "`3.3.2.0`").
 pub fn version() -> String {
-	use types::BOOL;
+	use crate::capi::sctypes::BOOL;
 	let v1 = (_API.SciterVersion)(true as BOOL);
 	let v2 = (_API.SciterVersion)(false as BOOL);
 	let num = [v1 >> 16, v1 & 0xFFFF, v2 >> 16, v2 & 0xFFFF];
@@ -543,23 +550,22 @@ pub fn is_windowless() -> bool {
 /// See also [per-window options](window/enum.Options.html).
 #[derive(Copy, Clone)]
 pub enum RuntimeOptions<'a> {
-
-  /// global; value: the full path to the Sciter dynamic library (dll/dylib/so),
-  /// must be called before any other Sciter function.
-  LibraryPath(&'a str),
-  /// global; value: [`GFX_LAYER`](enum.GFX_LAYER.html), must be called before any window creation.
-  GfxLayer(GFX_LAYER),
-  /// global; value: `true` - the engine will use a "unisex" theme that is common for all platforms.
-  /// That UX theme is not using OS primitives for rendering input elements.
-  /// Use it if you want exactly the same (modulo fonts) look-n-feel on all platforms.
-  UxTheming(bool),
-  /// global or per-window; enables Sciter Inspector for all windows, must be called before any window creation.
-  DebugMode(bool),
-  /// global or per-window; value: combination of [`SCRIPT_RUNTIME_FEATURES`](enum.SCRIPT_RUNTIME_FEATURES.html) flags.
-  ///
-  /// Note that these features have been disabled by default
-  /// since [4.2.5.0](https://rawgit.com/c-smile/sciter-sdk/7036a9c7912ac30d9f369d9abb87b278d2d54c6d/logfile.htm).
-  ScriptFeatures(u8),
+	/// global; value: the full path to the Sciter dynamic library (dll/dylib/so),
+	/// must be called before any other Sciter function.
+	LibraryPath(&'a str),
+	/// global; value: [`GFX_LAYER`](enum.GFX_LAYER.html), must be called before any window creation.
+	GfxLayer(GFX_LAYER),
+	/// global; value: `true` - the engine will use a "unisex" theme that is common for all platforms.
+	/// That UX theme is not using OS primitives for rendering input elements.
+	/// Use it if you want exactly the same (modulo fonts) look-n-feel on all platforms.
+	UxTheming(bool),
+	/// global or per-window; enables Sciter Inspector for all windows, must be called before any window creation.
+	DebugMode(bool),
+	/// global or per-window; value: combination of [`SCRIPT_RUNTIME_FEATURES`](enum.SCRIPT_RUNTIME_FEATURES.html) flags.
+	///
+	/// Note that these features have been disabled by default
+	/// since [4.2.5.0](https://rawgit.com/c-smile/sciter-sdk/7036a9c7912ac30d9f369d9abb87b278d2d54c6d/logfile.htm).
+	ScriptFeatures(u8),
 	/// global; value: milliseconds, connection timeout of http client.
 	ConnectionTimeout(u32),
 	/// global; value: `0` - drop connection, `1` - use builtin dialog, `2` - accept connection silently.
@@ -593,16 +599,12 @@ pub fn set_options(options: RuntimeOptions) -> std::result::Result<(), ()> {
 		MaxHttpDataLength(value) => (SCITER_SET_MAX_HTTP_DATA_LENGTH, value),
 		LogicalPixel(enable) => (SCITER_SET_PX_AS_DIP, enable as usize),
 
-    LibraryPath(path) => {
-      return set_library(path).map_err(|_|());
-    }
+		LibraryPath(path) => {
+			return set_library(path).map_err(|_| ());
+		}
 	};
 	let ok = (_API.SciterSetOption)(std::ptr::null_mut(), option, value);
-	if ok != 0 {
-		Ok(())
-	} else {
-		Err(())
-	}
+	if ok != 0 { Ok(()) } else { Err(()) }
 }
 
 /// Set a global variable by its path to all windows.
@@ -617,11 +619,7 @@ pub fn set_options(options: RuntimeOptions) -> std::result::Result<(), ()> {
 pub fn set_variable(path: &str, value: Value) -> dom::Result<()> {
 	let ws = s2u!(path);
 	let ok = (_API.SciterSetVariable)(std::ptr::null_mut(), ws.as_ptr(), value.as_cptr());
-	if ok == dom::SCDOM_RESULT::OK {
-		Ok(())
-	} else {
-		Err(ok)
-	}
+	if ok == dom::SCDOM_RESULT::OK { Ok(()) } else { Err(ok) }
 }
 
 /// Get a global variable by its path.
@@ -632,9 +630,5 @@ pub fn get_variable(path: &str) -> dom::Result<Value> {
 	let ws = s2u!(path);
 	let mut value = Value::new();
 	let ok = (_API.SciterGetVariable)(std::ptr::null_mut(), ws.as_ptr(), value.as_mut_ptr());
-	if ok == dom::SCDOM_RESULT::OK {
-		Ok(value)
-	} else {
-		Err(ok)
-	}
+	if ok == dom::SCDOM_RESULT::OK { Ok(value) } else { Err(ok) }
 }

--- a/src/om.rs
+++ b/src/om.rs
@@ -5,8 +5,8 @@ and [Sciter Object Model](http://sciter.com/developers/for-native-gui-programmer
 
 */
 use std::sync::atomic::{AtomicI32, Ordering};
-use capi::sctypes::{LPVOID, LPCSTR};
-pub use capi::scom::*;
+use crate::capi::sctypes::{LPVOID, LPCSTR};
+pub use crate::capi::scom::*;
 
 
 /// Get the index of an interned string.

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,38 +6,32 @@ Handling all attributes of requests (GET/POST/PUT/DELETE) sent by
 functions and other load requests.
 
 */
-pub use capi::screquest::{HREQUEST, REQUEST_RESULT};
-pub use capi::screquest::{REQUEST_METHOD, REQUEST_STATE, REQUEST_TYPE, RESOURCE_TYPE};
+pub use crate::capi::screquest::{HREQUEST, REQUEST_RESULT};
+pub use crate::capi::screquest::{REQUEST_METHOD, REQUEST_STATE, REQUEST_TYPE, RESOURCE_TYPE};
 
-use capi::sctypes::{LPVOID, UINT};
-use capi::scdef::{LPCWSTR_RECEIVER};
+use crate::capi::scdef::LPCWSTR_RECEIVER;
+use crate::capi::sctypes::{LPVOID, UINT};
 
-use utf::{store_astr, store_wstr, store_bstr};
+use crate::utf::{store_astr, store_bstr, store_wstr};
 
-use _RAPI;
-
-
+use crate::_RAPI;
 
 macro_rules! ok_or {
 	($ok:ident) => {
 		ok_or!((), $ok)
 	};
 
-  ($rv:expr, $ok:ident) => {
-    if $ok == REQUEST_RESULT::OK {
-      Ok($rv)
-    } else {
-      Err($ok)
-    }
-  };
+	($rv:expr, $ok:ident) => {
+		if $ok == REQUEST_RESULT::OK { Ok($rv) } else { Err($ok) }
+	};
 }
 
 /// A specialized `Result` type for request operations.
 pub type Result<T> = ::std::result::Result<T, REQUEST_RESULT>;
 
-type GetCountFn = extern "system" fn (rq: HREQUEST, pNumber: &mut UINT) -> REQUEST_RESULT;
-type GetNameFn = extern "system" fn (rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT;
-type GetValueFn = extern "system" fn (rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT;
+type GetCountFn = extern "system" fn(rq: HREQUEST, pnumber: &mut UINT) -> REQUEST_RESULT;
+type GetNameFn = extern "system" fn(rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT;
+type GetValueFn = extern "system" fn(rq: HREQUEST, n: UINT, rcv: LPCWSTR_RECEIVER, rcv_param: LPVOID) -> REQUEST_RESULT;
 
 /// Request object.
 ///
@@ -76,7 +70,7 @@ impl Clone for Request {
 impl From<HREQUEST> for Request {
 	fn from(hrq: HREQUEST) -> Request {
 		assert!(!hrq.is_null());
-  	(_RAPI.RequestUse)(hrq);
+		(_RAPI.RequestUse)(hrq);
 		Request(hrq)
 	}
 }
@@ -167,7 +161,12 @@ impl Request {
 		ok_or!(ok)
 	}
 
-	fn get_collection_impl(&self, get_count: GetCountFn, get_name: GetNameFn, get_value: GetValueFn) -> Result<std::collections::HashMap<String, String>>	{
+	fn get_collection_impl(
+		&self,
+		get_count: GetCountFn,
+		get_name: GetNameFn,
+		get_value: GetValueFn,
+	) -> Result<std::collections::HashMap<String, String>> {
 		let mut count = 0;
 		let ok = get_count(self.0, &mut count);
 		if ok != REQUEST_RESULT::OK {
@@ -195,12 +194,20 @@ impl Request {
 
 	/// Get the parameters of the request.
 	pub fn parameters(&self) -> Result<std::collections::HashMap<String, String>> {
-		self.get_collection_impl(_RAPI.RequestGetNumberOfParameters, _RAPI.RequestGetNthParameterName, _RAPI.RequestGetNthParameterValue)
+		self.get_collection_impl(
+			_RAPI.RequestGetNumberOfParameters,
+			_RAPI.RequestGetNthParameterName,
+			_RAPI.RequestGetNthParameterValue,
+		)
 	}
 
 	/// Get the headers of the request.
 	pub fn request_headers(&self) -> Result<std::collections::HashMap<String, String>> {
-		self.get_collection_impl(_RAPI.RequestGetNumberOfRqHeaders, _RAPI.RequestGetNthRqHeaderName, _RAPI.RequestGetNthRqHeaderValue)
+		self.get_collection_impl(
+			_RAPI.RequestGetNumberOfRqHeaders,
+			_RAPI.RequestGetNthRqHeaderName,
+			_RAPI.RequestGetNthRqHeaderValue,
+		)
 	}
 
 	/// Set request header (a single item).
@@ -213,7 +220,11 @@ impl Request {
 
 	/// Get the headers of the response.
 	pub fn response_headers(&self) -> Result<std::collections::HashMap<String, String>> {
-		self.get_collection_impl(_RAPI.RequestGetNumberOfRspHeaders, _RAPI.RequestGetNthRspHeaderName, _RAPI.RequestGetNthRspHeaderValue)
+		self.get_collection_impl(
+			_RAPI.RequestGetNumberOfRspHeaders,
+			_RAPI.RequestGetNthRspHeaderName,
+			_RAPI.RequestGetNthRspHeaderValue,
+		)
 	}
 
 	/// Set respone header (a single item).
@@ -275,5 +286,4 @@ impl Request {
 			Err(ok)
 		}
 	}
-
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 //! Export platform-dependent types used by Sciter.
 
-pub use capi::sctypes::*;
-pub use capi::scdef::*;
-pub use capi::scvalue::VALUE;
+pub use crate::capi::scdef::*;
+pub use crate::capi::sctypes::*;
+pub use crate::capi::scvalue::VALUE;

--- a/src/utf.rs
+++ b/src/utf.rs
@@ -5,29 +5,28 @@
 
 // (C) 2003-2015, Andrew Fedoniouk (andrew@terrainformatica.com)
 
-
 #![allow(dead_code)]
 
+use crate::capi::sctypes::{LPCBYTE, LPCSTR, LPCWSTR};
 use std::ffi::{CStr, CString};
-use capi::sctypes::{LPCSTR, LPCWSTR, LPCBYTE};
-
 
 /// UTF-8 to UTF-16 converter.
 #[allow(unused_parens)]
-fn towcs(utf: &[u8], outbuf: &mut Vec<u16>) -> bool
-{
+fn towcs(utf: &[u8], outbuf: &mut Vec<u16>) -> bool {
 	let errc = 0x003F; // '?'
 	let mut num_errors = 0;
 
 	let last = utf.len();
 	let mut pc = 0;
 	while (pc < last) {
-		let mut b = u32::from(utf[pc]); pc += 1;
-		if (b == 0) { break; }
+		let mut b = u32::from(utf[pc]);
+		pc += 1;
+		if (b == 0) {
+			break;
+		}
 
 		if ((b & 0x80) == 0) {
 			// 1-BYTE sequence: 000000000xxxxxxx = 0xxxxxxx
-
 		} else if ((b & 0xE0) == 0xC0) {
 			// 2-BYTE sequence: 00000yyyyyxxxxxx = 110yyyyy 10xxxxxx
 			if (pc == last) {
@@ -37,8 +36,8 @@ fn towcs(utf: &[u8], outbuf: &mut Vec<u16>) -> bool
 			}
 
 			b = (b & 0x1f) << 6;
-			b |= (u32::from(utf[pc]) & 0x3f); pc += 1;
-
+			b |= (u32::from(utf[pc]) & 0x3f);
+			pc += 1;
 		} else if ((b & 0xf0) == 0xe0) {
 			// 3-BYTE sequence: zzzzyyyyyyxxxxxx = 1110zzzz 10yyyyyy 10xxxxxx
 			if (pc >= last - 1) {
@@ -48,33 +47,40 @@ fn towcs(utf: &[u8], outbuf: &mut Vec<u16>) -> bool
 			}
 
 			b = (b & 0x0f) << 12;
-			b |= (u32::from(utf[pc]) & 0x3f) << 6; pc += 1;
-			b |= (u32::from(utf[pc]) & 0x3f); pc += 1;
+			b |= (u32::from(utf[pc]) & 0x3f) << 6;
+			pc += 1;
+			b |= (u32::from(utf[pc]) & 0x3f);
+			pc += 1;
 
-			if (b == 0xFEFF && outbuf.is_empty()) { // bom at start
+			if (b == 0xFEFF && outbuf.is_empty()) {
+				// bom at start
 				continue; // skip it
 			}
-
 		} else if ((b & 0xf8) == 0xf0) {
 			// 4-BYTE sequence: 11101110wwwwzzzzyy + 110111yyyyxxxxxx = 11110uuu 10uuzzzz 10yyyyyy 10xxxxxx
-			if(pc >= last - 2) { outbuf.push(errc); break; }
+			if (pc >= last - 2) {
+				outbuf.push(errc);
+				break;
+			}
 
 			b = (b & 0x07) << 18;
-			b |= (u32::from(utf[pc]) & 0x3f) << 12; pc += 1;
-			b |= (u32::from(utf[pc]) & 0x3f) << 6; pc += 1;
-			b |= (u32::from(utf[pc]) & 0x3f); pc += 1;
+			b |= (u32::from(utf[pc]) & 0x3f) << 12;
+			pc += 1;
+			b |= (u32::from(utf[pc]) & 0x3f) << 6;
+			pc += 1;
+			b |= (u32::from(utf[pc]) & 0x3f);
+			pc += 1;
 
 			// b shall contain now full 21-bit unicode code point.
 			assert!((b & 0x1f_ffff) == b);
-			if((b & 0x1f_ffff) != b) {
+			if ((b & 0x1f_ffff) != b) {
 				outbuf.push(errc);
 				num_errors += 1;
 				continue;
 			}
 
-			outbuf.push( (0xd7c0 + (b >> 10)) as u16 );
-			outbuf.push( (0xdc00 | (b & 0x3ff)) as u16 );
-
+			outbuf.push((0xd7c0 + (b >> 10)) as u16);
+			outbuf.push((0xdc00 | (b & 0x3ff)) as u16);
 		} else {
 			num_errors += 1;
 			b = u32::from(errc);
@@ -85,11 +91,9 @@ fn towcs(utf: &[u8], outbuf: &mut Vec<u16>) -> bool
 	return num_errors == 0;
 }
 
-
 /// UTF-16 to UTF-8 converter.
 #[allow(unused_parens)]
-fn fromwcs(wcs: &[u16], outbuf: &mut Vec<u8>) -> bool
-{
+fn fromwcs(wcs: &[u16], outbuf: &mut Vec<u8>) -> bool {
 	let mut num_errors = 0;
 
 	let last = wcs.len();
@@ -98,22 +102,18 @@ fn fromwcs(wcs: &[u16], outbuf: &mut Vec<u8>) -> bool
 		let c = u32::from(wcs[pc]);
 		if (c < (1 << 7)) {
 			outbuf.push(c as u8);
-
 		} else if (c < (1 << 11)) {
 			outbuf.push(((c >> 6) | 0xc0) as u8);
 			outbuf.push(((c & 0x3f) | 0x80) as u8);
-
 		} else if (c < (1 << 16)) {
 			outbuf.push(((c >> 12) | 0xe0) as u8);
 			outbuf.push((((c >> 6) & 0x3f) | 0x80) as u8);
 			outbuf.push(((c & 0x3f) | 0x80) as u8);
-
 		} else if (c < (1 << 21)) {
 			outbuf.push(((c >> 18) | 0xf0) as u8);
 			outbuf.push((((c >> 12) & 0x3f) | 0x80) as u8);
 			outbuf.push((((c >> 6) & 0x3f) | 0x80) as u8);
 			outbuf.push(((c & 0x3f) | 0x80) as u8);
-
 		} else {
 			num_errors += 1;
 		}
@@ -122,10 +122,8 @@ fn fromwcs(wcs: &[u16], outbuf: &mut Vec<u8>) -> bool
 	return num_errors == 0;
 }
 
-
 /// UTF-16 string length like `libc::wcslen`.
-fn wcslen(sz: LPCWSTR) -> usize
-{
+fn wcslen(sz: LPCWSTR) -> usize {
 	if sz.is_null() {
 		return 0;
 	}
@@ -141,8 +139,7 @@ fn wcslen(sz: LPCWSTR) -> usize
 }
 
 /// UTF8 to Rust string conversion. See also [`s2u!`](../macro.s2u.html).
-pub fn u2s(sz: LPCSTR) -> String
-{
+pub fn u2s(sz: LPCSTR) -> String {
 	if sz.is_null() {
 		return String::new();
 	}
@@ -152,8 +149,7 @@ pub fn u2s(sz: LPCSTR) -> String
 }
 
 /// UTF8 to Rust string conversion. See also [`s2u!`](../macro.s2u.html).
-pub fn u2sn(sz: LPCSTR, len: usize) -> String
-{
+pub fn u2sn(sz: LPCSTR, len: usize) -> String {
 	if sz.is_null() || len == 0 {
 		return String::new();
 	}
@@ -163,14 +159,12 @@ pub fn u2sn(sz: LPCSTR, len: usize) -> String
 }
 
 /// UTF-16 to Rust string conversion. See also [`s2w!`](../macro.s2w.html).
-pub fn w2s(sz: LPCWSTR) -> String
-{
+pub fn w2s(sz: LPCWSTR) -> String {
 	return w2sn(sz, wcslen(sz));
 }
 
 /// UTF-16 to Rust string conversion. See also [`s2w!`](../macro.s2w.html).
-pub fn w2sn(sz: LPCWSTR, len: usize) -> String
-{
+pub fn w2sn(sz: LPCWSTR, len: usize) -> String {
 	if sz.is_null() || len == 0 {
 		return String::new();
 	}
@@ -203,7 +197,7 @@ pub fn s2vecn(s: &str) -> (Vec<u16>, u32) {
 	return (out, n);
 }
 
-use capi::sctypes::{UINT, LPVOID};
+use crate::capi::sctypes::{LPVOID, UINT};
 
 /// Convert an incoming UTF-16 to `String`.
 pub(crate) extern "system" fn store_wstr(szstr: LPCWSTR, str_length: UINT, param: LPVOID) {
@@ -213,7 +207,7 @@ pub(crate) extern "system" fn store_wstr(szstr: LPCWSTR, str_length: UINT, param
 }
 
 /// Convert an incoming UTF-8 to `String`.
-pub(crate) extern "system" fn store_astr(szstr: LPCSTR,  str_length: UINT, param: LPVOID) {
+pub(crate) extern "system" fn store_astr(szstr: LPCSTR, str_length: UINT, param: LPVOID) {
 	let s = self::u2sn(szstr, str_length as usize);
 	let out = param as *mut String;
 	unsafe { *out = s };
@@ -226,18 +220,17 @@ pub(crate) extern "system" fn store_bstr(szstr: LPCBYTE, str_length: UINT, param
 	}
 	let s = unsafe { ::std::slice::from_raw_parts(szstr, str_length as usize) };
 	let pout = param as *mut Vec<u8>;
-	let out = unsafe {&mut *pout};
+	let out = unsafe { &mut *pout };
 	out.extend_from_slice(s);
 }
-
 
 #[cfg(test)]
 mod tests {
 	#![allow(unused_imports)]
 
+	use super::{s2vec, u2s, w2s, wcslen};
+	use crate::capi::sctypes::{LPCSTR, LPCWSTR};
 	use std::ffi::{CStr, CString};
-	use capi::sctypes::{LPCWSTR, LPCSTR};
-	use super::{wcslen, u2s, w2s, s2vec};
 
 	#[test]
 	fn test_wcslen() {
@@ -266,7 +259,7 @@ mod tests {
 		let nullptr: LPCWSTR = ::std::ptr::null();
 		assert_eq!(w2s(nullptr), String::new());
 
-		let v = vec![32, 32, 0];	// SP
+		let v = vec![32, 32, 0]; // SP
 		assert_eq!(w2s(v.as_ptr()), "  ");
 	}
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -88,9 +88,9 @@ methods:
 # #[macro_use] extern crate sciter;
 # fn main() {
 let map = vmap! {
-  "one" => 1,
-  "two" => 2.0,
-  "three" => "",
+	"one" => 1,
+	"two" => 2.0,
+	"three" => "",
 };
 assert!(map.is_map());
 assert_eq!(map.len(), 3);
@@ -157,34 +157,39 @@ assert!(v.get_item("one").is_int());
 .
 */
 
-use ::{_API};
+use crate::_API;
 
-use capi::sctypes::*;
-use capi::scvalue::{VALUE_UNIT_TYPE_STRING, VALUE_UNIT_TYPE_OBJECT, VALUE_UNIT_UNDEFINED};
-pub use capi::scvalue::{VALUE_RESULT, VALUE_STRING_CVT_TYPE, VALUE_TYPE};
-use capi::scvalue::VALUE;
-use ::om::IAsset;
-
+use crate::capi::sctypes::*;
+use crate::capi::scvalue::VALUE;
+pub use crate::capi::scvalue::{VALUE_RESULT, VALUE_STRING_CVT_TYPE, VALUE_TYPE};
+use crate::capi::scvalue::{VALUE_UNIT_TYPE_OBJECT, VALUE_UNIT_TYPE_STRING, VALUE_UNIT_UNDEFINED};
+use crate::om::IAsset;
 
 // TODO: `get`, `get_item` methods should return `Option<Value>`
 
 /// `sciter::value` wrapper.
 ///
 /// See the [module-level](index.html) documentation.
-pub struct Value
-{
+pub struct Value {
 	data: VALUE,
-	tmp: * mut Value,
+	//	tmp: *mut Value,
 }
 
 /// `sciter::Value` can be transferred across thread boundaries.
 unsafe impl Send for Value {}
 
 impl Value {
-
 	/// Return a new Sciter value object ([`undefined`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)).
-	pub const fn new() -> Value {
-		Value { data: VALUE::new(), tmp: ::std::ptr::null_mut() }
+	pub fn new() -> Value {
+		// let tmp_val = Value {
+		// 	data: VALUE::new(),
+		// 	tmp: std::ptr::null_mut(),
+		// };
+
+		Value {
+			data: VALUE::new(),
+			// tmp: Box::into_raw(Box::new(tmp_val)),
+		}
 	}
 
 	/// Make an explicit [array](https://sciter.com/docs/content/script/Array.htm) value with the given length.
@@ -202,13 +207,13 @@ impl Value {
 	}
 
 	/// Make an explicit json [null](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null) value.
-	pub const fn null() -> Value {
+	pub fn null() -> Value {
 		let mut me = Value::new();
 		me.data.t = VALUE_TYPE::T_NULL;
 		return me;
 	}
 	/// Make an explicit `nothing` (where did it come from?).
-	pub const fn nothing() -> Value {
+	pub fn nothing() -> Value {
 		let mut me = Value::new();
 		me.data.t = VALUE_TYPE::T_UNDEFINED;
 		me.data.u = VALUE_UNIT_UNDEFINED::UT_NOTHING as UINT;
@@ -258,20 +263,16 @@ impl Value {
 	/// Parse a json string into value. Returns the number of chars left unparsed in case of error.
 	pub fn parse_as(val: &str, how: VALUE_STRING_CVT_TYPE) -> Result<Value, usize> {
 		let mut me = Value::new();
-		let (s,n) = s2wn!(val);
+		let (s, n) = s2wn!(val);
 		let ok: u32 = (_API.ValueFromString)(me.as_ptr(), s.as_ptr(), n, how);
-		if ok == 0 {
-			Ok(me)
-		} else {
-			Err(ok as usize)
-		}
+		if ok == 0 { Ok(me) } else { Err(ok as usize) }
 	}
 
 	/// Value to asset.
 	pub fn to_asset<T>(&self) -> Option<&mut IAsset<T>> {
 		if self.is_asset() {
 			let mut val = 0_i64;
-			if (_API.ValueInt64Data)(self.as_cptr(), &mut val)  == VALUE_RESULT::OK {
+			if (_API.ValueInt64Data)(self.as_cptr(), &mut val) == VALUE_RESULT::OK {
 				let ptr = val as usize as *mut IAsset<T>;
 				let asset = unsafe { &mut *ptr };
 				return Some(asset);
@@ -378,8 +379,8 @@ impl Value {
 	/// * `T_OBJECT` - names of key/value properties in the object;
 	/// * `T_FUNCTION` - names of arguments of the function (if any).
 	///
-  /// The iterator element type is `Value` (as a key).
-	pub fn keys(&self) -> KeyIterator {
+	/// The iterator element type is `Value` (as a key).
+	pub fn keys(&self) -> KeyIterator<'_> {
 		KeyIterator {
 			base: self,
 			index: 0,
@@ -394,8 +395,8 @@ impl Value {
 	/// * `T_OBJECT` - values of key/value properties in the object;
 	/// * `T_FUNCTION` - values of arguments of the function.
 	///
-  /// The iterator element type is `Value`.
-	pub fn values(&self) -> SeqIterator {
+	/// The iterator element type is `Value`.
+	pub fn values(&self) -> SeqIterator<'_> {
 		SeqIterator {
 			base: self,
 			index: 0,
@@ -405,8 +406,8 @@ impl Value {
 
 	/// An iterator visiting all key-value pairs in arbitrary order.
 	///
-  /// The `Value` must has a key-value type (map, object, function).
-  ///
+	/// The `Value` must has a key-value type (map, object, function).
+	///
 	/// The iterator element type is `(Value, Value)`.
 	pub fn items(&self) -> Vec<(Value, Value)> {
 		type VecType = Vec<(Value, Value)>;
@@ -434,7 +435,7 @@ impl Value {
 		let mut val = 0i32;
 		match (_API.ValueIntData)(self.as_cptr(), &mut val) {
 			VALUE_RESULT::OK => Some(val),
-			_ => None
+			_ => None,
 		}
 	}
 
@@ -443,7 +444,7 @@ impl Value {
 		let mut val = 0i32;
 		match (_API.ValueIntData)(self.as_cptr(), &mut val) {
 			VALUE_RESULT::OK => Some(val != 0),
-			_ => None
+			_ => None,
 		}
 	}
 
@@ -452,7 +453,7 @@ impl Value {
 		let mut val = 0f64;
 		match (_API.ValueFloatData)(self.as_cptr(), &mut val) {
 			VALUE_RESULT::OK => Some(val),
-			_ => None
+			_ => None,
 		}
 	}
 
@@ -461,7 +462,7 @@ impl Value {
 		let mut val = 0i32;
 		match (_API.ValueIntData)(self.as_cptr(), &mut val) {
 			VALUE_RESULT::OK => Some(val as u32),
-			_ => None
+			_ => None,
 		}
 	}
 
@@ -470,7 +471,7 @@ impl Value {
 		let mut val = 0f64;
 		match (_API.ValueFloatData)(self.as_cptr(), &mut val) {
 			VALUE_RESULT::OK => Some(val),
-			_ => None
+			_ => None,
 		}
 	}
 
@@ -479,7 +480,7 @@ impl Value {
 		let mut val = 0f64;
 		match (_API.ValueFloatData)(self.as_cptr(), &mut val) {
 			VALUE_RESULT::OK => Some(val),
-			_ => None
+			_ => None,
 		}
 	}
 
@@ -488,8 +489,8 @@ impl Value {
 		let mut s = 0 as LPCWSTR;
 		let mut n = 0_u32;
 		match (_API.ValueStringData)(self.as_cptr(), &mut s, &mut n) {
-			VALUE_RESULT::OK => Some(::utf::w2sn(s, n as usize)),
-			_ => None
+			VALUE_RESULT::OK => Some(crate::utf::w2sn(s, n as usize)),
+			_ => None,
 		}
 	}
 
@@ -505,7 +506,7 @@ impl Value {
 		let mut n = 0_u32;
 		match (_API.ValueBinaryData)(self.as_cptr(), &mut s, &mut n) {
 			VALUE_RESULT::OK => Some(unsafe { ::std::slice::from_raw_parts(s, n as usize) }),
-			_ => None
+			_ => None,
 		}
 	}
 
@@ -527,11 +528,17 @@ impl Value {
 		let mut rv = Value::new();
 		let argv = Value::pack_args(args);
 		let name = s2w!(name.unwrap_or(""));
-		let ok = (_API.ValueInvoke)(self.as_cptr(), this.unwrap_or_default().as_ptr(),
-			argv.len() as UINT, argv.as_ptr(), rv.as_ptr(), name.as_ptr());
+		let ok = (_API.ValueInvoke)(
+			self.as_cptr(),
+			this.unwrap_or_default().as_ptr(),
+			argv.len() as UINT,
+			argv.as_ptr(),
+			rv.as_ptr(),
+			name.as_ptr(),
+		);
 		match ok {
 			VALUE_RESULT::OK => Ok(rv),
-			_ => Err(ok)
+			_ => Err(ok),
 		}
 	}
 
@@ -552,11 +559,14 @@ impl Value {
 	}
 
 	#[doc(hidden)]
-	pub unsafe fn unpack_from(args: * const VALUE, count: UINT) -> Vec<Value> {
+	pub fn unpack_from(args: *const VALUE, count: UINT) -> Vec<Value> {
 		let argc = count as usize;
 		let mut argv: Vec<Value> = Vec::with_capacity(argc);
-		assert!(argc == 0 || !args.is_null());
-		let args = ::std::slice::from_raw_parts(args, argc);
+		if argc == 0 {
+			return argv;
+		}
+		assert!(!args.is_null());
+		let args = unsafe { std::slice::from_raw_parts(args, argc) };
 		for arg in args {
 			argv.push(Value::copy_from(arg));
 		}
@@ -564,28 +574,27 @@ impl Value {
 	}
 
 	#[doc(hidden)]
-	unsafe fn copy_from(ptr: *const VALUE) -> Value {
+	fn copy_from(ptr: *const VALUE) -> Value {
 		assert!(!ptr.is_null());
 		let mut v = Value::new();
 		(_API.ValueCopy)(v.as_ptr(), ptr);
 		return v;
 	}
 
-  #[allow(clippy::mut_from_ref)]
+	#[allow(clippy::mut_from_ref)]
 	fn ensure_tmp_mut(&self) -> &mut Value {
-		let cp = self as *const Value;
-		let mp = cp as *mut Value;
-		let me = unsafe { &mut *mp };
-		return me.ensure_tmp();
-	}
-
-	fn ensure_tmp(&mut self) -> &mut Value {
-		if self.tmp.is_null() {
-			let tmp = Box::new(Value::new());
-			self.tmp = Box::into_raw(tmp);
+		unsafe {
+			let pptr = self as *const Value as *mut *mut Value;
+			&mut *(*pptr)
 		}
-		return unsafe { &mut *self.tmp };
 	}
+	// fn ensure_tmp(&mut self) -> &mut Value {
+	// 	if self.tmp.is_null() {
+	// 		let tmp = Box::new(Value::new());
+	// 		self.tmp = Box::into_raw(tmp);
+	// 	}
+	// 	return unsafe { &mut *self.tmp };
+	// }
 
 	/// Returns `true` is `self` is `undefined` or has zero elements.
 	pub fn is_empty(&self) -> bool {
@@ -679,71 +688,63 @@ impl Value {
 
 	/// I.e. non-reference types that do not need a destructor.
 	pub const fn is_primitive(&self) -> bool {
-		use capi::scvalue::VALUE_TYPE::*;
-		matches!(self.data.t,
-			T_UNDEFINED
-			| T_NULL
-			| T_BOOL
-			| T_INT
-			| T_FLOAT
-			| T_DATE
-		)
+		use crate::capi::scvalue::VALUE_TYPE::*;
+		matches!(self.data.t, T_UNDEFINED | T_NULL | T_BOOL | T_INT | T_FLOAT | T_DATE)
 	}
 
-  // script types:
-  #[allow(missing_docs)]
-  pub const fn is_object_array(&self) -> bool {
-    self.data.t as u32 == VALUE_TYPE::T_OBJECT as u32 && self.data.u == VALUE_UNIT_TYPE_OBJECT::ARRAY as UINT
-  }
-  #[allow(missing_docs)]
-  pub const fn is_object_map(&self) -> bool {
-    self.data.t as u32 == VALUE_TYPE::T_OBJECT as u32 && self.data.u == VALUE_UNIT_TYPE_OBJECT::OBJECT as UINT
-  }
-  #[allow(missing_docs)]
-  pub const fn is_object_class(&self) -> bool {
-    self.data.t as u32 == VALUE_TYPE::T_OBJECT as u32 && self.data.u == VALUE_UNIT_TYPE_OBJECT::OBJECT as UINT
-  }
-  #[allow(missing_docs)]
-  pub const fn is_object_native(&self) -> bool {
-    self.data.t as u32 == VALUE_TYPE::T_OBJECT as u32 && self.data.u == VALUE_UNIT_TYPE_OBJECT::NATIVE as UINT
-  }
-  #[allow(missing_docs)]
-  pub const fn is_object_function(&self) -> bool {
-    self.data.t as u32 == VALUE_TYPE::T_OBJECT as u32 && self.data.u == VALUE_UNIT_TYPE_OBJECT::FUNCTION as UINT
-  }
-  #[allow(missing_docs)]
-  pub const fn is_object_error(&self) -> bool {
-    self.data.t as u32 == VALUE_TYPE::T_OBJECT as u32 && self.data.u == VALUE_UNIT_TYPE_OBJECT::ERROR as UINT
-  }
+	// script types:
+	#[allow(missing_docs)]
+	pub const fn is_object_array(&self) -> bool {
+		self.data.t as u32 == VALUE_TYPE::T_OBJECT as u32 && self.data.u == VALUE_UNIT_TYPE_OBJECT::ARRAY as UINT
+	}
+	#[allow(missing_docs)]
+	pub const fn is_object_map(&self) -> bool {
+		self.data.t as u32 == VALUE_TYPE::T_OBJECT as u32 && self.data.u == VALUE_UNIT_TYPE_OBJECT::OBJECT as UINT
+	}
+	#[allow(missing_docs)]
+	pub const fn is_object_class(&self) -> bool {
+		self.data.t as u32 == VALUE_TYPE::T_OBJECT as u32 && self.data.u == VALUE_UNIT_TYPE_OBJECT::OBJECT as UINT
+	}
+	#[allow(missing_docs)]
+	pub const fn is_object_native(&self) -> bool {
+		self.data.t as u32 == VALUE_TYPE::T_OBJECT as u32 && self.data.u == VALUE_UNIT_TYPE_OBJECT::NATIVE as UINT
+	}
+	#[allow(missing_docs)]
+	pub const fn is_object_function(&self) -> bool {
+		self.data.t as u32 == VALUE_TYPE::T_OBJECT as u32 && self.data.u == VALUE_UNIT_TYPE_OBJECT::FUNCTION as UINT
+	}
+	#[allow(missing_docs)]
+	pub const fn is_object_error(&self) -> bool {
+		self.data.t as u32 == VALUE_TYPE::T_OBJECT as u32 && self.data.u == VALUE_UNIT_TYPE_OBJECT::ERROR as UINT
+	}
 	#[allow(missing_docs)]
 	pub const fn is_dom_element(&self) -> bool {
 		self.data.t as u32 == VALUE_TYPE::T_DOM_OBJECT as u32
 	}
 
-  // generic check (native or object):
-  #[allow(missing_docs)]
-  pub const fn is_varray(&self) -> bool {
-    self.is_array() || self.is_object()
-  }
-  #[allow(missing_docs)]
-  pub const fn is_vmap(&self) -> bool {
-    self.is_map() || self.is_object_map()
-  }
-  #[allow(missing_docs)]
-  pub fn is_vfunction(&self) -> bool {
-    self.is_function() || self.is_object_function() || self.is_native_function()
-  }
-  #[allow(missing_docs)]
-  pub const fn is_verror(&self) -> bool {
-    self.is_error_string() || self.is_object_error()
-  }
+	// generic check (native or object):
+	#[allow(missing_docs)]
+	pub const fn is_varray(&self) -> bool {
+		self.is_array() || self.is_object()
+	}
+	#[allow(missing_docs)]
+	pub const fn is_vmap(&self) -> bool {
+		self.is_map() || self.is_object_map()
+	}
+	#[allow(missing_docs)]
+	pub fn is_vfunction(&self) -> bool {
+		self.is_function() || self.is_object_function() || self.is_native_function()
+	}
+	#[allow(missing_docs)]
+	pub const fn is_verror(&self) -> bool {
+		self.is_error_string() || self.is_object_error()
+	}
 
 	fn assign_str(&mut self, val: &str, unit: VALUE_UNIT_TYPE_STRING) -> VALUE_RESULT {
-		let (s,n) = s2wn!(val);
+		let (s, n) = s2wn!(val);
 		return (_API.ValueStringDataSet)(self.as_ptr(), s.as_ptr(), n, unit as UINT);
 	}
 }
-
 
 /// Print `Value` as json string
 impl ::std::fmt::Display for Value {
@@ -757,22 +758,23 @@ impl ::std::fmt::Display for Value {
 /// Print `Value` as json string with explicit type showed.
 impl ::std::fmt::Debug for Value {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-
 		let mut tname = format!("{:?}", self.data.t);
 
 		if self.is_undefined() || self.is_null() {
 			return f.write_str(&tname[2..].to_lowercase());
-
 		} else if self.is_nothing() {
 			return f.write_str("nothing");
-
 		} else if self.is_string() && self.data.u != 0 {
 			// VALUE_UNIT_TYPE_STRING
 			let units = [
-				("file", 0xfffe), ("symbol", 0xffff),
-				("string", 0), ("error", 1), ("secure", 2),
-				("url", 3), ("selector", 4),
-				];
+				("file", 0xfffe),
+				("symbol", 0xffff),
+				("string", 0),
+				("error", 1),
+				("secure", 2),
+				("url", 3),
+				("selector", 4),
+			];
 
 			tname.push(':');
 			if let Some(name) = units.iter().find(|&&x| x.1 == self.data.u) {
@@ -780,7 +782,6 @@ impl ::std::fmt::Debug for Value {
 			} else {
 				tname.push_str(&self.data.u.to_string());
 			}
-
 		} else if self.is_object() {
 			// VALUE_UNIT_TYPE_OBJECT
 			let units = ["array", "object", "class", "native", "function", "error"];
@@ -791,7 +792,6 @@ impl ::std::fmt::Debug for Value {
 			} else {
 				tname.push_str(&u.to_string());
 			}
-
 		} else if self.data.u != 0 {
 			// VALUE_UNIT_TYPE
 			// redundant? like "length:7:12px" instead of "length:12px" (7 == `UT_PX`).
@@ -809,9 +809,9 @@ impl ::std::fmt::Debug for Value {
 impl Drop for Value {
 	fn drop(&mut self) {
 		// drop the attached side-data if any.
-		if !self.tmp.is_null() {
-			let _drop_tmp = unsafe { Box::from_raw(self.tmp) };
-		}
+		// if !self.tmp.is_null() {
+		// 	let _drop_tmp = unsafe { Box::from_raw(self.tmp) };
+		// }
 		if std::thread::panicking() {
 			// it is fine to do nothing for the non-reference types.
 			if self.is_primitive() {
@@ -859,7 +859,7 @@ impl ::std::ops::Index<usize> for Value {
 	}
 }
 
-/// Set item by index for array type.
+/* /// Set item by index for array type.
 #[cfg(notworking)]
 impl ::std::ops::IndexMut<usize> for Value {
 	fn index_mut(&mut self, index: usize) -> &mut Value {
@@ -868,7 +868,7 @@ impl ::std::ops::IndexMut<usize> for Value {
 		return tmp;
 	}
 }
-
+ */
 /// Get item by key for map type.
 impl ::std::ops::Index<Value> for Value {
 	type Output = Value;
@@ -889,7 +889,7 @@ impl ::std::ops::Index<&'static str> for Value {
 	}
 }
 
-/// Set item by key for map type.
+/* /// Set item by key for map type.
 #[cfg(notworking)]
 impl ::std::ops::IndexMut<Value> for Value {
 	fn index_mut<'a>(&'a mut self, key: Value) -> &'a mut Value {
@@ -899,7 +899,7 @@ impl ::std::ops::IndexMut<Value> for Value {
 		return tmp;
 	}
 }
-
+ */
 /// Value from nothing (`()`) for empty return values.
 ///
 /// Returns `undefined` value.
@@ -911,9 +911,9 @@ impl From<()> for Value {
 
 /// Value from a native `VALUE` object.
 impl<'a> From<&'a VALUE> for Value {
-  fn from(val: &'a VALUE) -> Self {
-    unsafe { Value::copy_from(val as *const _) }
-  }
+	fn from(val: &'a VALUE) -> Self {
+		Value::copy_from(val as *const _)
+	}
 }
 
 /// Value from integer.
@@ -1035,7 +1035,11 @@ impl From<std::time::SystemTime> for Value {
 }
 
 /// Value from [`Result`].
-impl<T, E> From<Result<T, E>> for Value where T: Into<Value>, E: std::fmt::Display {
+impl<T, E> From<Result<T, E>> for Value
+where
+	T: Into<Value>,
+	E: std::fmt::Display,
+{
 	fn from(val: Result<T, E>) -> Self {
 		match val {
 			Ok(v) => v.into(),
@@ -1059,25 +1063,25 @@ impl<T, E> From<Result<T, E>> for Value where T: Into<Value>, E: std::fmt::Displ
 
 /// Value from sequence of `Value`.
 impl ::std::iter::FromIterator<Value> for Value {
-  fn from_iter<I: IntoIterator<Item=Value>>(iterator: I) -> Self {
-    let iterator = iterator.into_iter();
-    let capacity = iterator.size_hint().0;
-    let mut v = Value::array(capacity);
-    for (i, m) in iterator.enumerate() {
-      v.set(i, m);
-    }
-    return v;
-  }
+	fn from_iter<I: IntoIterator<Item = Value>>(iterator: I) -> Self {
+		let iterator = iterator.into_iter();
+		let capacity = iterator.size_hint().0;
+		let mut v = Value::array(capacity);
+		for (i, m) in iterator.enumerate() {
+			v.set(i, m);
+		}
+		return v;
+	}
 }
 
 /// Value from sequence of `i32`.
 impl ::std::iter::FromIterator<i32> for Value {
-	fn from_iter<I: IntoIterator<Item=i32>>(iterator: I) -> Self {
-    let iterator = iterator.into_iter();
-    let capacity = iterator.size_hint().0;
+	fn from_iter<I: IntoIterator<Item = i32>>(iterator: I) -> Self {
+		let iterator = iterator.into_iter();
+		let capacity = iterator.size_hint().0;
 		let mut v = Value::array(capacity);
-    for (i, m) in iterator.enumerate() {
-      v.set(i, Value::from(m));
+		for (i, m) in iterator.enumerate() {
+			v.set(i, Value::from(m));
 		}
 		return v;
 	}
@@ -1085,12 +1089,12 @@ impl ::std::iter::FromIterator<i32> for Value {
 
 /// Value from sequence of `f64`.
 impl ::std::iter::FromIterator<f64> for Value {
-	fn from_iter<I: IntoIterator<Item=f64>>(iterator: I) -> Self {
-    let iterator = iterator.into_iter();
-    let capacity = iterator.size_hint().0;
-    let mut v = Value::array(capacity);
-    for (i, m) in iterator.enumerate() {
-      v.set(i, Value::from(m));
+	fn from_iter<I: IntoIterator<Item = f64>>(iterator: I) -> Self {
+		let iterator = iterator.into_iter();
+		let capacity = iterator.size_hint().0;
+		let mut v = Value::array(capacity);
+		for (i, m) in iterator.enumerate() {
+			v.set(i, Value::from(m));
 		}
 		return v;
 	}
@@ -1098,12 +1102,12 @@ impl ::std::iter::FromIterator<f64> for Value {
 
 /// Value from sequence of `&str`.
 impl<'a> ::std::iter::FromIterator<&'a str> for Value {
-	fn from_iter<I: IntoIterator<Item=&'a str>>(iterator: I) -> Self {
-    let iterator = iterator.into_iter();
-    let capacity = iterator.size_hint().0;
-    let mut v = Value::array(capacity);
-    for (i, m) in iterator.enumerate() {
-      v.set(i, Value::from(m));
+	fn from_iter<I: IntoIterator<Item = &'a str>>(iterator: I) -> Self {
+		let iterator = iterator.into_iter();
+		let capacity = iterator.size_hint().0;
+		let mut v = Value::array(capacity);
+		for (i, m) in iterator.enumerate() {
+			v.set(i, Value::from(m));
 		}
 		return v;
 	}
@@ -1111,12 +1115,12 @@ impl<'a> ::std::iter::FromIterator<&'a str> for Value {
 
 /// Value from sequence of `String`.
 impl ::std::iter::FromIterator<String> for Value {
-	fn from_iter<I: IntoIterator<Item=String>>(iterator: I) -> Self {
-    let iterator = iterator.into_iter();
-    let capacity = iterator.size_hint().0;
-    let mut v = Value::array(capacity);
-    for (i, m) in iterator.enumerate() {
-      v.set(i, Value::from(m));
+	fn from_iter<I: IntoIterator<Item = String>>(iterator: I) -> Self {
+		let iterator = iterator.into_iter();
+		let capacity = iterator.size_hint().0;
+		let mut v = Value::array(capacity);
+		for (i, m) in iterator.enumerate() {
+			v.set(i, Value::from(m));
 		}
 		return v;
 	}
@@ -1131,8 +1135,8 @@ where
 	fn from(f: F) -> Value {
 		let mut v = Value::new();
 		let boxed = Box::new(f);
-		let ptr = Box::into_raw(boxed);	// dropped in `_functor_release`
-		(_API.ValueNativeFunctorSet)(v.as_ptr(), _functor_invoke::<F,R>, _functor_release::<F>, ptr as LPVOID);
+		let ptr = Box::into_raw(boxed); // dropped in `_functor_release`
+		(_API.ValueNativeFunctorSet)(v.as_ptr(), _functor_invoke::<F, R>, _functor_release::<F>, ptr as LPVOID);
 		return v;
 	}
 }
@@ -1147,8 +1151,7 @@ impl<T> From<Box<IAsset<T>>> for Value {
 	}
 }
 
-extern "C" fn _functor_release<F>(tag: LPVOID)
-{
+extern "C" fn _functor_release<F>(tag: LPVOID) {
 	// reconstruct handler from pointer
 	let ptr = tag as *mut F;
 	let boxed = unsafe { Box::from_raw(ptr) };
@@ -1165,17 +1168,18 @@ where
 	let ptr = tag as *mut F;
 	let me = unsafe { &mut *ptr };
 	let retval = unsafe { &mut *retval };
-	let args = unsafe { Value::unpack_from(argv, argc) };
+	let args = Value::unpack_from(argv, argc);
 	let rv = me(&args);
 	let rv: Value = rv.into();
 	rv.pack_to(retval)
 }
 
-
 /// Helper trait
 pub trait FromValue {
 	/// Converts value to specified type.
-	fn from_value(v: &Value) -> Option<Self> where Self: Sized;
+	fn from_value(v: &Value) -> Option<Self>
+	where
+		Self: Sized;
 }
 
 impl FromValue for Value {
@@ -1213,7 +1217,6 @@ impl FromValue for String {
 		v.as_string()
 	}
 }
-
 
 /// An iterator visiting all keys of key/value pairs in the map-like `Value` objects.
 #[doc(hidden)]
@@ -1256,7 +1259,6 @@ impl<'a> ::std::iter::DoubleEndedIterator for KeyIterator<'a> {
 		}
 	}
 }
-
 
 /// An iterator over the sub-elements of a `Value`.
 #[doc(hidden)]
@@ -1312,15 +1314,14 @@ impl<'a> ::std::iter::IntoIterator for &'a Value {
 	}
 }
 
-
 #[cfg(test)]
 mod tests {
 	#![allow(unused_imports)]
 
-	use super::{Value, FromValue};
-	use capi::scvalue::{VALUE, VALUE_TYPE};
+	use super::{FromValue, Value};
+	use crate::_API;
+	use crate::capi::scvalue::{VALUE, VALUE_TYPE};
 	use std::mem;
-	use ::{_API};
 
 	fn check1(a: i32) {
 		assert_eq!(a, 12);
@@ -1329,12 +1330,12 @@ mod tests {
 	#[test]
 	fn test_from_value() {
 		let v = Value::from(12);
-		check1(
-			match FromValue::from_value(&v) {
-				Some(x) => { x },
-				None => { return; }
+		check1(match FromValue::from_value(&v) {
+			Some(x) => x,
+			None => {
+				return;
 			}
-		);
+		});
 	}
 
 	#[test]
@@ -1345,8 +1346,11 @@ mod tests {
 
 	#[test]
 	fn test_abi() {
-
-		let mut data = VALUE { t: VALUE_TYPE::T_UNDEFINED, u: 0, d: 0 };
+		let mut data = VALUE {
+			t: VALUE_TYPE::T_UNDEFINED,
+			u: 0,
+			d: 0,
+		};
 		assert_eq!(data.t, VALUE_TYPE::T_UNDEFINED);
 
 		(_API.ValueInit)(&mut data);

--- a/src/value.rs
+++ b/src/value.rs
@@ -172,7 +172,6 @@ use crate::om::IAsset;
 /// See the [module-level](index.html) documentation.
 pub struct Value {
 	data: VALUE,
-	//	tmp: *mut Value,
 }
 
 /// `sciter::Value` can be transferred across thread boundaries.
@@ -181,14 +180,8 @@ unsafe impl Send for Value {}
 impl Value {
 	/// Return a new Sciter value object ([`undefined`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)).
 	pub fn new() -> Value {
-		// let tmp_val = Value {
-		// 	data: VALUE::new(),
-		// 	tmp: std::ptr::null_mut(),
-		// };
-
 		Value {
 			data: VALUE::new(),
-			// tmp: Box::into_raw(Box::new(tmp_val)),
 		}
 	}
 
@@ -588,13 +581,6 @@ impl Value {
 			&mut *(*pptr)
 		}
 	}
-	// fn ensure_tmp(&mut self) -> &mut Value {
-	// 	if self.tmp.is_null() {
-	// 		let tmp = Box::new(Value::new());
-	// 		self.tmp = Box::into_raw(tmp);
-	// 	}
-	// 	return unsafe { &mut *self.tmp };
-	// }
 
 	/// Returns `true` is `self` is `undefined` or has zero elements.
 	pub fn is_empty(&self) -> bool {

--- a/src/video.rs
+++ b/src/video.rs
@@ -5,8 +5,8 @@ Host application can render custom video streams using `<video>` infrastructure.
 */
 
 
-use capi::sctypes::{UINT, LPCBYTE, LPCSTR};
-use capi::scom::som_passport_t;
+use crate::capi::sctypes::{UINT, LPCBYTE, LPCSTR};
+use crate::capi::scom::som_passport_t;
 
 /// A type alias for Sciter functions that return `bool`.
 pub type Result<T> = ::std::result::Result<T, ()>;


### PR DESCRIPTION
added use `crate::` where were errors
`scdef.rs` defines `SCITER_CREATE_WINDOW_FLAGS` as `bitflags!` and `.bits()` is used to take u32
`value.rs` creates `Value::tmp` in `Value::new` and `Value::ensure_tmp` is not used